### PR TITLE
Provide a Dockerfile to build a standard development image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:jessie
+
+ENV ARCH=x86_64-unknown-linux-gnu
+ENV RUST_RELEASE=1.9.0
+ENV LLVM_RELEASE=3.9
+ENV CARGO_RELEASE=nightly
+
+RUN echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie main" > /etc/apt/sources.list.d/llvm.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+    apt-get update && \
+    apt-get install -y curl llvm-$LLVM_RELEASE vim gcc libssl-dev libedit-dev libstdc++-4.9-dev && \
+    find /usr/bin -executable -iname llvm* | xargs -n1 -I file echo ln -s file file | sed s/-$LLVM_RELEASE$// | bash
+
+RUN curl -sL https://static.rust-lang.org/dist/rust-$RUST_RELEASE-$ARCH.tar.gz | tar xvz -C /tmp && \
+    /tmp/rust-$RUST_RELEASE-$ARCH/install.sh && \
+    rm -rf /tmp/rust-$RUST_RELEASE-$ARCH
+
+RUN curl -sL https://static.rust-lang.org/cargo-dist/cargo-$CARGO_RELEASE-$ARCH.tar.gz | tar xvz -C /tmp && \
+    /tmp/cargo-$CARGO_RELEASE-$ARCH/install.sh && \
+    rm -rf /tmp/cargo-$CARGO_RELEASE-$ARCH
+
+RUN apt-get remove --purge -y curl && \
+    apt-get autoclean && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+VOLUME /source
+WORKDIR /source

--- a/README.md
+++ b/README.md
@@ -25,6 +25,30 @@ To build a development version:
 $ cargo build
 ```
 
+### Using Docker
+
+If installing Rust and LLVM on your machine is too much, Docker might be an
+alternative: It provides everything needed to build, test and run Tagua VM.
+
+First, build the Docker image:
+
+```sh
+$ docker build -t tagua-vm-parser-dev
+```
+
+Now, it is possible to run a container from this image:
+
+```sh
+$ docker run --rm -it -v $(pwd):/source tagua-vm-parser-dev
+```
+
+If this command succeeds, you are inside a fresh container. To see if
+everything is fine, you can start the test suite:
+
+```sh
+$ cargo test
+```
+
 ## Contributing
 
 Do whatever you want. Just respect the license and the other contributors. Your


### PR DESCRIPTION
This is the exact same `Dockerfile` as the one I pushed to tagua-vm/tagua-vm.

It provides an easy to setup development environment for the parser library.
