### PR TITLE
Test: Unignore a documentation test

### DIFF
--- a/source/lib.rs
+++ b/source/lib.rs
@@ -71,8 +71,8 @@ pub mod tokens;
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use taguavm::language::parser;
+/// ```
+/// use taguavm_parser as parser;
 ///
 /// let expression = b"1+2";
 /// parser::parse(&expression[..]);


### PR DESCRIPTION
Fix #20.

So far, there is only one documentation test. Now we are sure it is up-to-date and works correctly.

```
   Doc-tests taguavm_parser

running 1 test
test parse_0 ... ok
```

Please @jubianchi, can you do the review?
