### PR TITLE
Token: Add operators and punctuators

### DIFF
--- a/source/rules/expressions.rs
+++ b/source/rules/expressions.rs
@@ -39,7 +39,7 @@ named!(
     pub expr<ast::Addition>,
     chain!(
         left: decimal ~
-        tag!(token::PLUS) ~
+        tag!(token::ADD) ~
         right: decimal,
         || ast::Addition { a: ast::Term { t: left }, b: ast::Term { t: right } }
     )

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -49,499 +49,504 @@
 macro_rules! token {
     ($name:ident: $value:expr; $documentation:expr) => (
         #[doc=$documentation]
+        const $name: &'static str = $value;
+    );
+
+    (pub $name:ident: $value:expr; $documentation:expr) => (
+        #[doc=$documentation]
         pub const $name: &'static str = $value;
     )
 }
 
 token!(
-    ABSTRACT: "abstract";
+    pub ABSTRACT: "abstract";
     "The `ABSTRACT` token.\n\nRepresent an abstract entity, e.g. `abstract class C { … }`."
 );
 token!(
-    ADD: "+";
+    pub ADD: "+";
     "The `ADD` token.\n\nRepresent the addition operator, e.g. `$x + $y`."
 );
 token!(
-    ADD_AND_ASSIGN: "+=";
+    pub ADD_AND_ASSIGN: "+=";
     "The `ADD_AND_ASSIGN` token.\n\nRepresent the addition assignment operator, e.g. `$x += $y;`."
 );
 token!(
-    AND: "and";
+    pub AND: "and";
     "The `AND` token.\n\nRepresent the conjunction operator, used in a logical expression, e.g. `$x and $y`."
 );
 token!(
-    ARRAY: "array";
+    pub ARRAY: "array";
     "The `ARRAY` token.\n\nRepresent the array constructor, e.g. `array($x, $y)`."
 );
 token!(
-    AS: "as";
+    pub AS: "as";
     "The `AS` token.\n\nRepresent the alias operator, e.g. `use Foo\\Bar as Baz`."
 );
 token!(
-    ASSIGN: "=";
+    pub ASSIGN: "=";
     "The `ASSIGN` token.\n\nRepresent a binding of a value to a variable, e.g. `$x = 42`."
 );
 token!(
-    BITWISE_AND: "&";
+    pub BITWISE_AND: "&";
     "The `BITWISE_AND` token.\n\nRepresent the bitwise conjunction operator, e.g. `$x & $y`."
 );
 token!(
-    BITWISE_AND_AND_ASSIGN: "&=";
+    pub BITWISE_AND_AND_ASSIGN: "&=";
     "The `BITWISE_AND_AND_ASSIGN` token.\n\nRepresent the bitwise conjunction assignment operator, e.g. `$x &= $y;`."
 );
 token!(
-    BITWISE_LEFT_SHIFT: "<<";
+    pub BITWISE_LEFT_SHIFT: "<<";
     "The `BITWISE_LEFT_SHIFT` token.\n\nRepresent the bitwise left shift operator, e.g. `$x << $y`."
 );
 token!(
-    BITWISE_LEFT_SHIFT_AND_ASSIGN: "<<=";
+    pub BITWISE_LEFT_SHIFT_AND_ASSIGN: "<<=";
     "The `BITWISE_LEFT_SHIFT_AND_ASSIGN` token.\n\nRepresent the bitwise left shift assignment operator, e.g. `$x <<= $y;`."
 );
 token!(
-    BITWISE_NOT: "~";
+    pub BITWISE_NOT: "~";
     "The `BITWISE_NOT` token.\n\nRepresent the bitwise negation operator, e.g. `~$x`."
 );
 token!(
-    BITWISE_OR: "|";
+    pub BITWISE_OR: "|";
     "The `BITWISE_OR` token.\n\nRepresent the inclusive bitwise disjunction operator, e.g. `$x | $y`."
 );
 token!(
-    BITWISE_OR_AND_ASSIGN: "|=";
+    pub BITWISE_OR_AND_ASSIGN: "|=";
     "The `BITWISE_OR_AND_ASSIGN` token.\n\nRepresent the inclusive bitwise disjunction assignment operator, e.g. `$x |= $y;`."
 );
 token!(
-    BITWISE_RIGHT_SHIFT: ">>";
+    pub BITWISE_RIGHT_SHIFT: ">>";
     "The `BITWISE_RIGHT_SHIFT` token.\n\nRepresent the bitwise right shift operator, e.g. `$x >> $y`."
 );
 token!(
-    BITWISE_RIGHT_SHIFT_AND_ASSIGN: "<<=";
+    pub BITWISE_RIGHT_SHIFT_AND_ASSIGN: "<<=";
     "The `BITWISE_RIGHT_SHIFT_AND_ASSIGN` token.\n\nRepresent the bitwise right shift assignment operator, e.g. `$x >>= $y;`."
 );
 token!(
-    BITWISE_XOR: "^";
+    pub BITWISE_XOR: "^";
     "The `BITWISE_XOR` token.\n\nRepresent the exclusive bitwise disjunction operator, e.g. `$x ^ $y`."
 );
 token!(
-    BITWISE_XOR_AND_ASSIGN: "^=";
+    pub BITWISE_XOR_AND_ASSIGN: "^=";
     "The `BITWISE_XOR_AND_ASSIGN` token.\n\nRepresent the exclusive bitwise disjunction assignment operator, e.g. `$x ^= $y;`."
 );
 token!(
-    BOOLEAN_AND: "&&";
+    pub BOOLEAN_AND: "&&";
     "The `BOOLEAN_AND` token.\n\nRepresent the boolean conjunction operator, e.g. `$x && $y`."
 );
 token!(
-    BOOLEAN_NOT: "!";
+    pub BOOLEAN_NOT: "!";
     "The `NOT` token.\n\nRepresent the boolean negation operator, e.g. `!$x`."
 );
 token!(
-    BOOLEAN_OR: "||";
+    pub BOOLEAN_OR: "||";
     "The `BOOLEAN_OR` token.\n\nRepresent the boolean disjunction operator, e.g. `$x || $y`."
 );
 token!(
-    BREAK: "break";
+    pub BREAK: "break";
     "The `BREAK` token.\n\nRepresent the control flow breaker operator, e.g. `break 2`."
 );
 token!(
-    CALLABLE: "callable";
+    pub CALLABLE: "callable";
     "The `CALLABLE` token.\n\nRepresent the callable type, e.g. `function f(callable $x) { … }`."
 );
 token!(
-    CASE: "case";
+    pub CASE: "case";
     "The `CASE` token.\n\nRepresent a case in a `switch` control structure, e.g. `switch (…) { case …: …; }`."
 );
 token!(
-    CATCH: "catch";
+    pub CATCH: "catch";
     "The `CATCH` token.\n\nRepresent the `catch` block of a `try`/`catch` control structure, e.g. `try { … } catch (Exception $e) { … }`."
 );
 token!(
-    CLASS: "class";
+    pub CLASS: "class";
     "The `CLASS` token.\n\nRepresent the class declaration operator, e.g. `class C { … }`."
 );
 token!(
-    CLONE: "clone";
+    pub CLONE: "clone";
     "The `CLONE` token.\n\nRepresent the clone operator, e.g. `clone $x`."
 );
 token!(
-    COALESCE: "??";
+    pub COALESCE: "??";
     "The `COALESCE` token.\n\nRepresent the null coalescing operator, e.g. `$x ?? $y`."
 );
 token!(
-    COMMA: ",";
+    pub COMMA: ",";
     "The `COMMA` token.\n\nRepresent the list item separator, e.g. `($x, $y, $z)`."
 );
 token!(
-    COMPARE: "<=>";
+    pub COMPARE: "<=>";
     "The `COMPARE` token.\n\nRepresent the comparison operator, e.g. `$x <=> $y`."
 );
 token!(
-    CONCATENATE: ".";
+    pub CONCATENATE: ".";
     "The `CONCATENATE` token.\n\nRepresent the concatenation operator, e.g. `'foo' . 'bar'`."
 );
 token!(
-    CONCATENATE_AND_ASSIGN: ".=";
+    pub CONCATENATE_AND_ASSIGN: ".=";
     "The `CONCATENATE_AND_ASSIGN` token.\n\nRepresent the concatenation assignment operator, e.g. `$x .= $y;`."
 );
 token!(
-    CONST: "const";
+    pub CONST: "const";
     "The `CONST` token.\n\nRepresent the constant declaration operator, e.g. `const ANSWER = 42;`."
 );
 token!(
-    CONTINUE: "continue";
+    pub CONTINUE: "continue";
     "The `CONTINUE` token.\n\nRepresent the control flow continuer operator, e.g. `continue 2;`."
 );
 token!(
-    DECLARE: "declare";
+    pub DECLARE: "declare";
     "The `DECLARE` token.\n\nRepresent the declaration operator, e.g. `declare(foo='bar');`."
 );
 token!(
-    DECREMENT: "--";
+    pub DECREMENT: "--";
     "The `DECREMENT` token.\n\nRepresent the decrement operator, e.g. `$number--`."
 );
 token!(
-    DEFAULT: "default";
+    pub DEFAULT: "default";
     "The `DEFAULT` token.\n\nRepresent the default case in a `switch` control structure, e.g. `switch (…) { … default: …; }`."
 );
 token!(
-    DIE: "die";
+    pub DIE: "die";
     "The `DIE` token.\n\nRepresent the termination operator, e.g. `die(42);`."
 );
 token!(
-    DIVIDE: "/";
+    pub DIVIDE: "/";
     "The `DIVIDE` token.\n\nRepresent the division operator, e.g. `$x / $y`."
 );
 token!(
-    DIVIDE_AND_ASSIGN: "/=";
+    pub DIVIDE_AND_ASSIGN: "/=";
     "The `DIVIDE_AND_ASSIGN` token.\n\nRepresent the division assignment operator, e.g. `$x /= $y`."
 );
 token!(
-    DO: "do";
+    pub DO: "do";
     "The `DO` token.\n\nRepresent the body of a `do`/`while` loop, e.g. `do { … } while (…);`."
 );
 token!(
-    DYNAMIC_CALL: "->";
+    pub DYNAMIC_CALL: "->";
     "The `DYNAMIC_CALL` token.\n\nRepresent the dynamic method call operator, e.g. `$object->method()`."
 );
 token!(
-    ECHO: "echo";
+    pub ECHO: "echo";
     "The `ECHO` token.\n\nRepresent the output writer operator, e.g. `echo 'foobar';`."
 );
 token!(
-    ELLIPSIS: "...";
+    pub ELLIPSIS: "...";
     "The `ELLIPSIS` token.\n\nRepresent the ellipsis operator, e.g. `$x...`."
 );
 token!(
-    ELSE: "else";
+    pub ELSE: "else";
     "The `ELSE` token.\n\nRepresent the falsy block of a condition control structure, e.g. `if (…) { … } else { … }`."
 );
 token!(
-    ELSEIF: "elseif";
+    pub ELSEIF: "elseif";
     "The `ELSEIF` token.\n\nRepresent a `else if` block, e.g. `if (…) { … } elseif { … } else { … }`."
 );
 token!(
-    EMPTY: "empty";
+    pub EMPTY: "empty";
     "The `EMPTY` token.\n\nRepresent the emptiness operator, e.g. `empty($x)`."
 );
 token!(
-    ENDDECLARE: "enddeclare";
+    pub ENDDECLARE: "enddeclare";
     "The `ENDDECLARE` token.\n\nRepresent the end of a `declare` block, e.g. `declare: … enddeclare`."
 );
 token!(
-    ENDFOR: "endfor";
+    pub ENDFOR: "endfor";
     "The `ENDFOR` token.\n\nRepresent the end of a `for` block, e.g. `for (…; …; …): … endfor`."
 );
 token!(
-    ENDFOREACH: "endforeach";
+    pub ENDFOREACH: "endforeach";
     "The `ENDFOREACH` token.\n\nRepresent the end of a `foreach` block, e.g. `foreach ($i as $k => $v): … endforeach`."
 );
 token!(
-    ENDIF: "endif";
+    pub ENDIF: "endif";
     "The `ENDIF` token.\n\nRepresent the end of an `if` block, e.g. `if (…): … endif`."
 );
 token!(
-    ENDSWITCH: "endswitch";
+    pub ENDSWITCH: "endswitch";
     "The `ENDSWITCH` token.\n\nRepresent the end of a `switch` block, e.g. `switch(…): … endswitch`."
 );
 token!(
-    ENDWHILE: "endwhile";
+    pub ENDWHILE: "endwhile";
     "The `ENDWHILE` token.\n\nRepresent the end of a `while` block, e.g. `while(…): … endwhile`."
 );
 token!(
-    EQUAL: "==";
+    pub EQUAL: "==";
     "The `EQUAL` token.\n\nRepresent the equality comparison operator, e.g. `$x == $y`."
 );
 token!(
-    EVAL: "eval";
+    pub EVAL: "eval";
     "The `EVAL` token.\n\nRepresent the late-evaluation operator, e.g. `eval($x)`."
 );
 token!(
-    EXIT: "exit";
+    pub EXIT: "exit";
     "The `EXIT` token.\n\nRepresent the termination operator, e.g. `exit(42);`."
 );
 token!(
-    EXTENDS: "extends";
+    pub EXTENDS: "extends";
     "The `EXTENDS` token.\n\nRepresent the inheritance operator, e.g. `class C extends D { … }`."
 );
 token!(
-    FINAL: "final";
+    pub FINAL: "final";
     "The `FINAL` token.\n\nRepresent a final entity, e.g. `final class C { … }`."
 );
 token!(
-    FINALLY: "finally";
+    pub FINALLY: "finally";
     "The `FINALLY` token.\n\nRepresent the finally block of a `try`/`catch` control structure, e.g. `try { … } catch (…) { … } finally { … }`."
 );
 token!(
-    FOR: "for";
+    pub FOR: "for";
     "The `FOR` token.\n\nRepresent a `for` loop, e.g. `for (…; …; …) { … }`."
 );
 token!(
-    FOREACH: "foreach";
+    pub FOREACH: "foreach";
     "The `FOREACH` token.\n\nRepresent a `foreach` loop, e.g. `foreach ($i as $k => $v) { … }`."
 );
 token!(
-    FUNCTION: "function";
+    pub FUNCTION: "function";
     "The `FUNCTION` token.\n\nRepresent the function declaration operator, e.g. `function f(…) { … }`."
 );
 token!(
-    GLOBAL: "global";
+    pub GLOBAL: "global";
     "The `GLOBAL` token.\n\nRepresent the global visibility modifier, e.g. `global $x`."
 );
 token!(
-    GOTO: "goto";
+    pub GOTO: "goto";
     "The `GOTO` token.\n\nRepresent the jump operator, e.g. `goto x;`."
 );
 token!(
-    GREATER_THAN: ">";
+    pub GREATER_THAN: ">";
     "The `GREATER_THAN` token.\n\nRepresent the greater than comparison operator, e.g. `$x > $y`."
 );
 token!(
-    GREATER_THAN_OR_EQUAL_TO: ">=";
+    pub GREATER_THAN_OR_EQUAL_TO: ">=";
     "The `GREATER_THAN_OR_EQUAL_TO` token.\n\nRepresent the greater than or equal to comparison operator, e.g. `$x >= $y`."
 );
 token!(
-    IDENTICAL: "===";
+    pub IDENTICAL: "===";
     "The `IDENTICAL` token.\n\nRepresent the strict equality comparison operator, e.g. `$x === $y`."
 );
 token!(
-    IF: "if";
+    pub IF: "if";
     "The `IF` token.\n\nRepresent the truly block of a condition control structure, e.g. `if (…) { … }`."
 );
 token!(
-    IMPLEMENTS: "implements";
+    pub IMPLEMENTS: "implements";
     "The `IMPLEMENTS` token.\n\nRepresent the implementation operator, e.g. `class C implements I { … }`."
 );
 token!(
-    INCLUDE: "include";
+    pub INCLUDE: "include";
     "The `INCLUDE` token.\n\nRepresent the import operator, e.g. `include $x;`."
 );
 token!(
-    INCLUDE_ONCE: "include_once";
+    pub INCLUDE_ONCE: "include_once";
     "The `INCLUDE_ONCE` token.\n\nRepresent the import once operator, e.g. `include_once $x;`."
 );
 token!(
-    INCREMENT: "++";
+    pub INCREMENT: "++";
     "The `INCREMENT` token.\n\nRepresent the increment operator, e.g. `$number++`."
 );
 token!(
-    INSTANCEOF: "instanceof";
+    pub INSTANCEOF: "instanceof";
     "The `INSTANCEOF` token.\n\nRepresent the subset operator, e.g. `$o instanceof C`."
 );
 token!(
-    INSTEADOF: "insteadof";
+    pub INSTEADOF: "insteadof";
     "The `INSTEADOF` token.\n\nRepresent the conflict resolution operator, `use C, D { C::f insteadof D }`."
 );
 token!(
-    INTERFACE: "interface";
+    pub INTERFACE: "interface";
     "The `INTERFACE` token.\n\nRepresent the interface declaration operator, e.g. `interface I { … }`."
 );
 token!(
-    ISSET: "isset";
+    pub ISSET: "isset";
     "The `ISSET` token.\n\nRepresent the existence operator, e.g. `isset($x)`."
 );
 token!(
-    LEFT_CURLY_BRACKET: "{";
+    pub LEFT_CURLY_BRACKET: "{";
     "The `LEFT_CURLY_BRACKET` token.\n\nUsed to open a block, e.g. `if (…) { … }`."
 );
 token!(
-    LEFT_PARENTHESIS: "]";
+    pub LEFT_PARENTHESIS: "]";
     "The `LEFT_PARENTHESIS` token.\n\nUsed to open a group of something, e.g. `if (…)`."
 );
 token!(
-    LEFT_SQUARE_BRACKET: "[";
+    pub LEFT_SQUARE_BRACKET: "[";
     "The `LEFT_SQUARE_BRACKET` token.\n\nUsed to open an array construction or an array access for instance, e.g. `[2, 4, 6, 9][0]`."
 );
 token!(
-    LESS_THAN: "<";
+    pub LESS_THAN: "<";
     "The `LESS_THAN` token.\n\nRepresent the less than comparison operator, e.g. `$x < $y`."
 );
 token!(
-    LESS_THAN_OR_EQUAL_TO: "<=";
+    pub LESS_THAN_OR_EQUAL_TO: "<=";
     "The `LESS_THAN_OR_EQUAL_TO` token.\n\nRepresent the less than or equal to comparison operator, e.g. `$x <= $y`."
 );
 token!(
-    LIST: "list";
+    pub LIST: "list";
     "The `LIST` token.\n\nRepresent the destructuring operator, e.g. `list($x, $y) = $a`."
 );
 token!(
-    MODULO: "%";
+    pub MODULO: "%";
     "The `MODULO` token.\n\nRepresent the modulus operator, e.g. `$x % $y`."
 );
 token!(
-    MODULO_AND_ASSIGN: "%=";
+    pub MODULO_AND_ASSIGN: "%=";
     "The `MODULO_AND_ASSIGN` token.\n\nRepresent the modulus assignment operator, e.g. `$x %= $y;`."
 );
 token!(
-    MULTIPLY: "*";
+    pub MULTIPLY: "*";
     "The `MULTIPLY` token.\n\nRepresent the multiplication operator, e.g. `$x * $y`."
 );
 token!(
-    MULTIPLY_AND_ASSIGN: "*=";
+    pub MULTIPLY_AND_ASSIGN: "*=";
     "The `MULTIPLY_AND_ASSIGN` token.\n\nRepresent the multiplication assignment operator, e.g. `$x *= $y;`."
 );
 token!(
-    NAMESPACE: "namespace";
+    pub NAMESPACE: "namespace";
     "The `NAMESPACE` token.\n\nRepresent the namespace declaration operator, e.g. `namespace N;`."
 );
 token!(
-    NEW: "new";
+    pub NEW: "new";
     "The `NEW` token.\n\nRepresent the instanciation operator, e.g. `new C()`."
 );
 token!(
-    NOT_EQUAL: "!=";
+    pub NOT_EQUAL: "!=";
     "The `NOT_EQUAL` token.\n\nRepresent the not equal comparison operator, e.g. `$x != $y`."
 );
 token!(
-    NOT_IDENTICAL: "!==";
+    pub NOT_IDENTICAL: "!==";
     "The `NOT_IDENTICAL` token.\n\nRepresent the strict not equal comparison operator, e.g. `$x !== $y`."
 );
 token!(
-    OR: "or";
+    pub OR: "or";
     "The `OR` token.\n\nRepresent the inclusive disjunction operator, used in a logical expression, e.g. `$x or $y`."
 );
 token!(
-    POW: "**";
+    pub POW: "**";
     "The `POW` token.\n\nRepresent the power operator, e.g. `$x ** $y`."
 );
 token!(
-    POW_AND_ASSIGN: "**=";
+    pub POW_AND_ASSIGN: "**=";
     "The `POW_AND_ASSIGN` token.\n\nRepresent the power assignment operator, e.g. `$x **= $y;`."
 );
 token!(
-    PRINT: "print";
+    pub PRINT: "print";
     "The `PRINT` token.\n\nRepresent another output writer operator, e.g. `print 'foobar';`, see `echo`."
 );
 token!(
-    PRIVATE: "private";
+    pub PRIVATE: "private";
     "The `PRIVATE` token.\n\nRepresent the private visibility operator, e.g. `private $x`."
 );
 token!(
-    PROTECTED: "protected";
+    pub PROTECTED: "protected";
     "The `PROTECTED` token.\n\nRepresent the protected visibility operator, e.g. `protected $x`."
 );
 token!(
-    PUBLIC: "public";
+    pub PUBLIC: "public";
     "The `PUBLIC` token.\n\nRepresent the public visibility operator, e.g. `public $x`."
 );
 token!(
-    REFERENCE: "&";
+    pub REFERENCE: "&";
     "The `REFERENCE` token.\n\nRepresent the reference operator, e.g. `&$x`."
 );
 token!(
-    REQUIRE: "require";
+    pub REQUIRE: "require";
     "The `REQUIRE` token.\n\nRepresent the import operator, e.g. `require $x;`."
 );
 token!(
-    REQUIRE_ONCE: "require_once";
+    pub REQUIRE_ONCE: "require_once";
     "The `REQUIRE_ONCE` token.\n\nRepresent the import once operator, e.g. `require_once $x;`."
 );
 token!(
-    RETURN: "return";
+    pub RETURN: "return";
     "The `RETURN` token.\n\nRepresent the return operator, e.g. `return $x;`."
 );
 token!(
-    RIGHT_CURLY_BRACKET: "{";
+    pub RIGHT_CURLY_BRACKET: "{";
     "The `RIGHT_CURLY_BRACKET` token.\n\nUsed to close a block, e.g. `if (…) { … }`."
 );
 token!(
-    RIGHT_PARENTHESIS: ")";
+    pub RIGHT_PARENTHESIS: ")";
     "The `RIGHT_PARENTHESIS` token.\n\nUsed to close a group of something, e.g. `if (…)`."
 );
 token!(
-    RIGHT_SQUARE_BRACKET: "]";
+    pub RIGHT_SQUARE_BRACKET: "]";
     "The `RIGHT_SQUARE_BRACKET` token.\n\nUsed to close an array construction or an array access for instance, e.g. `[2, 4, 6, 9][0]`."
 );
 token!(
-    SEMICOLON: ";";
+    pub SEMICOLON: ";";
     "The `SEMICOLON` token.\n\nRepresent the end of an instruction, e.g. `$x = …;`."
 );
 token!(
-    STATIC: "static";
+    pub STATIC: "static";
     "The `STATIC` token.\n\nRepresent the stack declaration operator, e.g. `static $x`."
 );
 token!(
-    STATIC_CALL: "::";
+    pub STATIC_CALL: "::";
     "The `STATIC_CALL` token.\n\nRepresent the static method call operator, e.g. `class::method()`."
 );
 token!(
-    SUBTRACT: "-";
+    pub SUBTRACT: "-";
     "The `SUBTRACT` token.\n\nRepresent the subtraction operator, e.g. `$x - $y`."
 );
 token!(
-    SUBTRACT_AND_ASSIGN: "-=";
+    pub SUBTRACT_AND_ASSIGN: "-=";
     "The `SUBTRACT_AND_ASSIGN` token.\n\nRepresent the subtraction assignment operator, e.g. `$x -= $y;`."
 );
 token!(
-    SWITCH: "switch";
+    pub SWITCH: "switch";
     "The `SWITCH` token.\n\nRepresent the switch control structure, e.g. `switch ($x) { … }`."
 );
 token!(
-    TERNARY_ELSE: ":";
+    pub TERNARY_ELSE: ":";
     "The `TERNARY_ELSE` token.\n\nRepresent the falsy block of a ternary condition, e.g. `$x ? … : …`."
 );
 token!(
-    TERNARY_THEN: "?";
+    pub TERNARY_THEN: "?";
     "The `TERNARY_THEN` token.\n\nRepresent the truly block of a ternary condition, e.g. `$x ? … : …`."
 );
 token!(
-    THROW: "throw";
+    pub THROW: "throw";
     "The `THROW` token.\n\nRepresent the throw exception operator, e.g. `throw $e;`."
 );
 token!(
-    TRAIT: "trait";
+    pub TRAIT: "trait";
     "The `TRAIT` token.\n\nRepresent the trait declaration operator, e.g. `trait T { … }`."
 );
 token!(
-    TRY: "try";
+    pub TRY: "try";
     "The `TRY` token.\n\nRepresent the `try` block of a `try`/`catch` control structure, e.g. `try { … } catch (Exception $e) { … }`."
 );
 token!(
-    UNSET: "unset";
+    pub UNSET: "unset";
     "The `UNSET` token.\n\nRepresent the destruction operator, e.g. `unset($x);`."
 );
 token!(
-    USE: "use";
+    pub USE: "use";
     "The `USE` token.\n\nRepresent the importing operator (for namespaces or traits for instance), e.g. `use C\\D;`."
 );
 token!(
-    VAR: "var";
+    pub VAR: "var";
     "The `VAR` token.\n\nRepresent the variable declaration operator (for old PHP versions), e.g. `var $x = …;`."
 );
 token!(
-    VARIABLE: "$";
+    pub VARIABLE: "$";
     "The `VARIABLE` token.\n\nRepresent the variable declaration operator, e.g. `$foo`."
 );
 token!(
-    WHILE: "while";
+    pub WHILE: "while";
     "The `WHILE` token.\n\nRepresent a `while` loop, e.g. `while (…) { … }`."
 );
 token!(
-    XOR: "xor";
+    pub XOR: "xor";
     "The `XOR` token.\n\nRepresent the exclusive disjunction operator, used in a logical expression, e.g. `$x xor $y`."
 );
 token!(
-    YIELD: "yield";
+    pub YIELD: "yield";
     "The `YIELD` token.\n\nRepresent the generator operator, e.g. `yield …;`."
 );
 token!(
-    YIELD_FROM: "yield from";
+    pub YIELD_FROM: "yield from";
     "The `YIELD_FROM` token.\n\nRepresent the delegated generator operator, e.g. `yield from …;`."
 );

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -82,10 +82,6 @@ token!(
     "The `ASSIGN` token.\n\nRepresent a binding of a value to a variable, e.g. `$x = 42`."
 );
 token!(
-    ASSIGN_REFERENCE: "=&";
-    "The `ASSIGN_REFERENCE` token.\n\nRepresent the reference assignment operator, e.g. `$x =& $y;`."
-);
-token!(
     BITWISE_AND: "&";
     "The `BITWISE_AND` token.\n\nRepresent the bitwise conjunction operator, e.g. `$x & $y`."
 );

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -58,6 +58,14 @@ token!(
     "The `ABSTRACT` token.\n\nRepresent an abstract entity, e.g. `abstract class C { … }`."
 );
 token!(
+    ADD: "+";
+    "The `ADD` token.\n\nRepresent the addition operator, e.g. `$x + $y`."
+);
+token!(
+    ADD_AND_ASSIGN: "+=";
+    "The `ADD_AND_ASSIGN` token.\n\nRepresent the addition assignment operator, e.g. `$x += $y;`."
+);
+token!(
     AND: "and";
     "The `AND` token.\n\nRepresent the conjunction operator, used in a logical expression, e.g. `$x and $y`."
 );
@@ -68,6 +76,70 @@ token!(
 token!(
     AS: "as";
     "The `AS` token.\n\nRepresent the alias operator, e.g. `use Foo\\Bar as Baz`."
+);
+token!(
+    ASSIGN: "=";
+    "The `ASSIGN` token.\n\nRepresent a binding of a value to a variable, e.g. `$x = 42`."
+);
+token!(
+    ASSIGN_REFERENCE: "=&";
+    "The `ASSIGN_REFERENCE` token.\n\nRepresent the reference assignment operator, e.g. `$x =& $y;`."
+);
+token!(
+    BITWISE_AND: "&";
+    "The `BITWISE_AND` token.\n\nRepresent the bitwise conjunction operator, e.g. `$x & $y`."
+);
+token!(
+    BITWISE_AND_AND_ASSIGN: "&=";
+    "The `BITWISE_AND_AND_ASSIGN` token.\n\nRepresent the bitwise conjunction assignment operator, e.g. `$x &= $y;`."
+);
+token!(
+    BITWISE_LEFT_SHIFT: "<<";
+    "The `BITWISE_LEFT_SHIFT` token.\n\nRepresent the bitwise left shift operator, e.g. `$x << $y`."
+);
+token!(
+    BITWISE_LEFT_SHIFT_AND_ASSIGN: "<<=";
+    "The `BITWISE_LEFT_SHIFT_AND_ASSIGN` token.\n\nRepresent the bitwise left shift assignment operator, e.g. `$x <<= $y;`."
+);
+token!(
+    BITWISE_NOT: "~";
+    "The `BITWISE_NOT` token.\n\nRepresent the bitwise negation operator, e.g. `~$x`."
+);
+token!(
+    BITWISE_OR: "|";
+    "The `BITWISE_OR` token.\n\nRepresent the inclusive bitwise disjunction operator, e.g. `$x | $y`."
+);
+token!(
+    BITWISE_OR_AND_ASSIGN: "|=";
+    "The `BITWISE_OR_AND_ASSIGN` token.\n\nRepresent the inclusive bitwise disjunction assignment operator, e.g. `$x |= $y;`."
+);
+token!(
+    BITWISE_RIGHT_SHIFT: ">>";
+    "The `BITWISE_RIGHT_SHIFT` token.\n\nRepresent the bitwise right shift operator, e.g. `$x >> $y`."
+);
+token!(
+    BITWISE_RIGHT_SHIFT_AND_ASSIGN: "<<=";
+    "The `BITWISE_RIGHT_SHIFT_AND_ASSIGN` token.\n\nRepresent the bitwise right shift assignment operator, e.g. `$x >>= $y;`."
+);
+token!(
+    BITWISE_XOR: "^";
+    "The `BITWISE_XOR` token.\n\nRepresent the exclusive bitwise disjunction operator, e.g. `$x ^ $y`."
+);
+token!(
+    BITWISE_XOR_AND_ASSIGN: "^=";
+    "The `BITWISE_XOR_AND_ASSIGN` token.\n\nRepresent the exclusive bitwise disjunction assignment operator, e.g. `$x ^= $y;`."
+);
+token!(
+    BOOLEAN_AND: "&&";
+    "The `BOOLEAN_AND` token.\n\nRepresent the boolean conjunction operator, e.g. `$x && $y`."
+);
+token!(
+    BOOLEAN_NOT: "!";
+    "The `NOT` token.\n\nRepresent the boolean negation operator, e.g. `!$x`."
+);
+token!(
+    BOOLEAN_OR: "||";
+    "The `BOOLEAN_OR` token.\n\nRepresent the boolean disjunction operator, e.g. `$x || $y`."
 );
 token!(
     BREAK: "break";
@@ -94,6 +166,26 @@ token!(
     "The `CLONE` token.\n\nRepresent the clone operator, e.g. `clone $x`."
 );
 token!(
+    COALESCE: "??";
+    "The `COALESCE` token.\n\nRepresent the null coalescing operator, e.g. `$x ?? $y`."
+);
+token!(
+    COMMA: ",";
+    "The `COMMA` token.\n\nRepresent the list item separator, e.g. `($x, $y, $z)`."
+);
+token!(
+    COMPARE: "<=>";
+    "The `COMPARE` token.\n\nRepresent the comparison operator, e.g. `$x <=> $y`."
+);
+token!(
+    CONCATENATE: ".";
+    "The `CONCATENATE` token.\n\nRepresent the concatenation operator, e.g. `'foo' . 'bar'`."
+);
+token!(
+    CONCATENATE_AND_ASSIGN: ".=";
+    "The `CONCATENATE_AND_ASSIGN` token.\n\nRepresent the concatenation assignment operator, e.g. `$x .= $y;`."
+);
+token!(
     CONST: "const";
     "The `CONST` token.\n\nRepresent the constant declaration operator, e.g. `const ANSWER = 42;`."
 );
@@ -106,6 +198,10 @@ token!(
     "The `DECLARE` token.\n\nRepresent the declaration operator, e.g. `declare(foo='bar');`."
 );
 token!(
+    DECREMENT: "--";
+    "The `DECREMENT` token.\n\nRepresent the decrement operator, e.g. `$number--`."
+);
+token!(
     DEFAULT: "default";
     "The `DEFAULT` token.\n\nRepresent the default case in a `switch` control structure, e.g. `switch (…) { … default: …; }`."
 );
@@ -114,16 +210,28 @@ token!(
     "The `DIE` token.\n\nRepresent the termination operator, e.g. `die(42);`."
 );
 token!(
+    DIVIDE: "/";
+    "The `DIVIDE` token.\n\nRepresent the division operator, e.g. `$x / $y`."
+);
+token!(
+    DIVIDE_AND_ASSIGN: "/=";
+    "The `DIVIDE_AND_ASSIGN` token.\n\nRepresent the division assignment operator, e.g. `$x /= $y`."
+);
+token!(
     DO: "do";
     "The `DO` token.\n\nRepresent the body of a `do`/`while` loop, e.g. `do { … } while (…);`."
 );
 token!(
-    DOLLARS: "$";
-    "The `DOLLARS` token.\n\nRepresent the introduction of a variable, e.g. `$x`."
+    DYNAMIC_CALL: "->";
+    "The `DYNAMIC_CALL` token.\n\nRepresent the dynamic method call operator, e.g. `$object->method()`."
 );
 token!(
     ECHO: "echo";
     "The `ECHO` token.\n\nRepresent the output writer operator, e.g. `echo 'foobar';`."
+);
+token!(
+    ELLIPSIS: "...";
+    "The `ELLIPSIS` token.\n\nRepresent the ellipsis operator, e.g. `$x...`."
 );
 token!(
     ELSE: "else";
@@ -162,8 +270,8 @@ token!(
     "The `ENDWHILE` token.\n\nRepresent the end of a `while` block, e.g. `while(…): … endwhile`."
 );
 token!(
-    EQUAL: "=";
-    "The `EQUAL` token.\n\nRepresent a binding of a value to a variable, e.g. `$x = 42`."
+    EQUAL: "==";
+    "The `EQUAL` token.\n\nRepresent the equality comparison operator, e.g. `$x == $y`."
 );
 token!(
     EVAL: "eval";
@@ -206,6 +314,18 @@ token!(
     "The `GOTO` token.\n\nRepresent the jump operator, e.g. `goto x;`."
 );
 token!(
+    GREATER_THAN: ">";
+    "The `GREATER_THAN` token.\n\nRepresent the greater than comparison operator, e.g. `$x > $y`."
+);
+token!(
+    GREATER_THAN_OR_EQUAL_TO: ">=";
+    "The `GREATER_THAN_OR_EQUAL_TO` token.\n\nRepresent the greater than or equal to comparison operator, e.g. `$x >= $y`."
+);
+token!(
+    IDENTICAL: "===";
+    "The `IDENTICAL` token.\n\nRepresent the strict equality comparison operator, e.g. `$x === $y`."
+);
+token!(
     IF: "if";
     "The `IF` token.\n\nRepresent the truly block of a condition control structure, e.g. `if (…) { … }`."
 );
@@ -220,6 +340,10 @@ token!(
 token!(
     INCLUDE_ONCE: "include_once";
     "The `INCLUDE_ONCE` token.\n\nRepresent the import once operator, e.g. `include_once $x;`."
+);
+token!(
+    INCREMENT: "++";
+    "The `INCREMENT` token.\n\nRepresent the increment operator, e.g. `$number++`."
 );
 token!(
     INSTANCEOF: "instanceof";
@@ -238,8 +362,44 @@ token!(
     "The `ISSET` token.\n\nRepresent the existence operator, e.g. `isset($x)`."
 );
 token!(
+    LEFT_CURLY_BRACKET: "{";
+    "The `LEFT_CURLY_BRACKET` token.\n\nUsed to open a block, e.g. `if (…) { … }`."
+);
+token!(
+    LEFT_PARENTHESIS: "]";
+    "The `LEFT_PARENTHESIS` token.\n\nUsed to open a group of something, e.g. `if (…)`."
+);
+token!(
+    LEFT_SQUARE_BRACKET: "[";
+    "The `LEFT_SQUARE_BRACKET` token.\n\nUsed to open an array construction or an array access for instance, e.g. `[2, 4, 6, 9][0]`."
+);
+token!(
+    LESS_THAN: "<";
+    "The `LESS_THAN` token.\n\nRepresent the less than comparison operator, e.g. `$x < $y`."
+);
+token!(
+    LESS_THAN_OR_EQUAL_TO: "<=";
+    "The `LESS_THAN_OR_EQUAL_TO` token.\n\nRepresent the less than or equal to comparison operator, e.g. `$x <= $y`."
+);
+token!(
     LIST: "list";
     "The `LIST` token.\n\nRepresent the destructuring operator, e.g. `list($x, $y) = $a`."
+);
+token!(
+    MODULO: "%";
+    "The `MODULO` token.\n\nRepresent the modulus operator, e.g. `$x % $y`."
+);
+token!(
+    MODULO_AND_ASSIGN: "%=";
+    "The `MODULO_AND_ASSIGN` token.\n\nRepresent the modulus assignment operator, e.g. `$x %= $y;`."
+);
+token!(
+    MULTIPLY: "*";
+    "The `MULTIPLY` token.\n\nRepresent the multiplication operator, e.g. `$x * $y`."
+);
+token!(
+    MULTIPLY_AND_ASSIGN: "*=";
+    "The `MULTIPLY_AND_ASSIGN` token.\n\nRepresent the multiplication assignment operator, e.g. `$x *= $y;`."
 );
 token!(
     NAMESPACE: "namespace";
@@ -250,12 +410,24 @@ token!(
     "The `NEW` token.\n\nRepresent the instanciation operator, e.g. `new C()`."
 );
 token!(
-    OR: "or";
-    "The `OR` token.\n\nRepresent the disjunction operator, used in a logical expression, e.g. `$x or $y`."
+    NOT_EQUAL: "!=";
+    "The `NOT_EQUAL` token.\n\nRepresent the not equal comparison operator, e.g. `$x != $y`."
 );
 token!(
-    PLUS: "+";
-    "The `PLUS` token.\n\nRepresent the addition operator, used for instance in an arithmetic operation, e.g. `1 + 2`."
+    NOT_IDENTICAL: "!==";
+    "The `NOT_IDENTICAL` token.\n\nRepresent the strict not equal comparison operator, e.g. `$x !== $y`."
+);
+token!(
+    OR: "or";
+    "The `OR` token.\n\nRepresent the inclusive disjunction operator, used in a logical expression, e.g. `$x or $y`."
+);
+token!(
+    POW: "**";
+    "The `POW` token.\n\nRepresent the power operator, e.g. `$x ** $y`."
+);
+token!(
+    POW_AND_ASSIGN: "**=";
+    "The `POW_AND_ASSIGN` token.\n\nRepresent the power assignment operator, e.g. `$x **= $y;`."
 );
 token!(
     PRINT: "print";
@@ -274,6 +446,10 @@ token!(
     "The `PUBLIC` token.\n\nRepresent the public visibility operator, e.g. `public $x`."
 );
 token!(
+    REFERENCE: "&";
+    "The `REFERENCE` token.\n\nRepresent the reference operator, e.g. `&$x`."
+);
+token!(
     REQUIRE: "require";
     "The `REQUIRE` token.\n\nRepresent the import operator, e.g. `require $x;`."
 );
@@ -286,16 +462,48 @@ token!(
     "The `RETURN` token.\n\nRepresent the return operator, e.g. `return $x;`."
 );
 token!(
-    SEMI_COLON: ";";
-    "The `SEMI_COLON` token.\n\nRepresent a terminator of an expression, e.g. `$x = 42;`."
+    RIGHT_CURLY_BRACKET: "{";
+    "The `RIGHT_CURLY_BRACKET` token.\n\nUsed to close a block, e.g. `if (…) { … }`."
+);
+token!(
+    RIGHT_PARENTHESIS: ")";
+    "The `RIGHT_PARENTHESIS` token.\n\nUsed to close a group of something, e.g. `if (…)`."
+);
+token!(
+    RIGHT_SQUARE_BRACKET: "]";
+    "The `RIGHT_SQUARE_BRACKET` token.\n\nUsed to close an array construction or an array access for instance, e.g. `[2, 4, 6, 9][0]`."
+);
+token!(
+    SEMICOLON: ";";
+    "The `SEMICOLON` token.\n\nRepresent the end of an instruction, e.g. `$x = …;`."
 );
 token!(
     STATIC: "static";
     "The `STATIC` token.\n\nRepresent the stack declaration operator, e.g. `static $x`."
 );
 token!(
+    STATIC_CALL: "::";
+    "The `STATIC_CALL` token.\n\nRepresent the static method call operator, e.g. `class::method()`."
+);
+token!(
+    SUBTRACT: "-";
+    "The `SUBTRACT` token.\n\nRepresent the subtraction operator, e.g. `$x - $y`."
+);
+token!(
+    SUBTRACT_AND_ASSIGN: "-=";
+    "The `SUBTRACT_AND_ASSIGN` token.\n\nRepresent the subtraction assignment operator, e.g. `$x -= $y;`."
+);
+token!(
     SWITCH: "switch";
     "The `SWITCH` token.\n\nRepresent the switch control structure, e.g. `switch ($x) { … }`."
+);
+token!(
+    TERNARY_ELSE: ":";
+    "The `TERNARY_ELSE` token.\n\nRepresent the falsy block of a ternary condition, e.g. `$x ? … : …`."
+);
+token!(
+    TERNARY_THEN: "?";
+    "The `TERNARY_THEN` token.\n\nRepresent the truly block of a ternary condition, e.g. `$x ? … : …`."
 );
 token!(
     THROW: "throw";
@@ -320,6 +528,10 @@ token!(
 token!(
     VAR: "var";
     "The `VAR` token.\n\nRepresent the variable declaration operator (for old PHP versions), e.g. `var $x = …;`."
+);
+token!(
+    VARIABLE: "$";
+    "The `VARIABLE` token.\n\nRepresent the variable declaration operator, e.g. `$foo`."
 );
 token!(
     WHILE: "while";

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -307,6 +307,10 @@ token!(
     "The `FUNCTION` token.\n\nRepresent the function declaration operator, e.g. `function f(…) { … }`."
 );
 token!(
+    pub FUNCTION_OUTPUT: COLON;
+    "The `FUNCTION_OUTPUT` token.\n\nRepresent the function return type declaration operator, e.g. `function f(…): … { … }`."
+);
+token!(
     pub GLOBAL: "global";
     "The `GLOBAL` token.\n\nRepresent the global visibility modifier, e.g. `global $x`."
 );
@@ -419,6 +423,10 @@ token!(
     "The `NOT_IDENTICAL` token.\n\nRepresent the strict not equal comparison operator, e.g. `$x !== $y`."
 );
 token!(
+    pub NULLABLE: QUESTION_MARK;
+    "The `NULLABLE` token.\n\nRepresent the nullable operation, e.g. `function f(?int $x) { … }`."
+);
+token!(
     pub OR: "or";
     "The `OR` token.\n\nRepresent the inclusive disjunction operator, used in a logical expression, e.g. `$x or $y`."
 );
@@ -499,11 +507,11 @@ token!(
     "The `SWITCH` token.\n\nRepresent the switch control structure, e.g. `switch ($x) { … }`."
 );
 token!(
-    pub TERNARY_ELSE: ":";
+    pub TERNARY_ELSE: COLON;
     "The `TERNARY_ELSE` token.\n\nRepresent the falsy block of a ternary condition, e.g. `$x ? … : …`."
 );
 token!(
-    pub TERNARY_THEN: "?";
+    pub TERNARY_THEN: QUESTION_MARK;
     "The `TERNARY_THEN` token.\n\nRepresent the truly block of a ternary condition, e.g. `$x ? … : …`."
 );
 token!(
@@ -549,4 +557,13 @@ token!(
 token!(
     pub YIELD_FROM: "yield from";
     "The `YIELD_FROM` token.\n\nRepresent the delegated generator operator, e.g. `yield from …;`."
+);
+
+token!(
+    COLON: ":";
+    "The `COLON` private token.\n\nSee `FUNCTION_OUTPUT` and `TERNARY_ELSE`."
+);
+token!(
+    QUESTION_MARK: "?";
+    "The `QUESTION_MARK` private token.\n\nSee `NULLABLE` and `TERNARY_THEN`."
 );


### PR DESCRIPTION
Address https://github.com/tagua-vm/parser/issues/5, #8.
#### Specification

https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#operators-and-punctuators
#### Progression
- [x] `[`,
- [x] `]`,
- [x] `(`,
- [x] `)`,
- [x] `{`,
- [x] `}`,
- [x] `.`,
- [x] `->`,
- [x] `++`,
- [x] `--`,
- [x] `**`,
- [x] `*`,
- [x] `+`,
- [x] `-`,
- [x] `~`,
- [x] `!`,
- [x] `$`,
- [x] `/`,
- [x] `%`,
- [x] `<<`,
- [x] `>>`,
- [x] `<`,
- [x] `>`,
- [x] `<=`,
- [x] `>=`,
- [x] `==`,
- [x] `===`,
- [x] `!=`,
- [x] `!==`,
- [x] `^`,
- [x] `|`,
- [x] `&`,
- [x] `&&`,
- [x] `||`,
- [x] `?`,
- [x] `:`,
- [x] `;`,
- [x] `=`,
- [x] `**=`,
- [x] `*=`,
- [x] `/=`,
- [x] `%=`,
- [x] `+=`,
- [x] `-=`,
- [x] `.=`,
- [x] `<<=`,
- [x] `>>=`,
- [x] `&=`,
- [x] `^=`,
- [x] `|=`,
- [x] `=&` (removed),
- [x] `,`,
- [x] `??`,
- [x] `<=>`,
- [x] `...`.
