### PR TITLE
Literal: General

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -55,3 +55,20 @@ pub struct Addition {
     /// The right-hand side of the addition.
     pub b: Term
 }
+
+/// A literal.
+#[derive(Debug, PartialEq)]
+pub enum Literal<'a> {
+    /// The null value.
+    Null,
+    /// A boolean.
+    Boolean(bool),
+    /// An integer.
+    Integer(u64),
+    /// A real.
+    Float(f64),
+    /// A string.
+    String(Vec<u8>),
+    /// An identifier.
+    Identifier(&'a [u8])
+}

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -56,16 +56,16 @@ pub struct Addition {
     pub b: Term
 }
 
-/// A literal.
+/// A literal represents a fixed value, aka an atom.
 #[derive(Debug, PartialEq)]
 pub enum Literal {
-    /// The null value.
+    /// A null pointer.
     Null,
-    /// A boolean.
+    /// A boolean, either `true` or `false`.
     Boolean(bool),
-    /// An integer.
+    /// An integer, for instance a binary, octal, decimal or hexadecimal number.
     Integer(u64),
-    /// A real.
+    /// A real, for instance an exponential number.
     Real(f64),
     /// A string.
     String(Vec<u8>),

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -66,7 +66,7 @@ pub enum Literal {
     /// An integer.
     Integer(u64),
     /// A real.
-    Float(f64),
+    Real(f64),
     /// A string.
     String(Vec<u8>),
     /// An identifier.

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -33,27 +33,27 @@
 
 /// A term.
 #[derive(Debug, PartialEq)]
-pub struct Term {
+pub struct Term<'a> {
     /// The term value.
-    pub t: u64
+    pub t: Literal<'a>
 }
 
 /// A binding of a value to a variable.
 #[derive(Debug, PartialEq)]
-pub struct Binding {
+pub struct Binding<'a> {
     ///
     pub variable: String,
     /// 
-    pub expression: Term
+    pub expression: Term<'a>
 }
 
 /// An addition of two terms.
 #[derive(Debug, PartialEq)]
-pub struct Addition {
+pub struct Addition<'a> {
     /// The left-hand side of the addition.
-    pub a: Term,
+    pub a: Term<'a>,
     /// The right-hand side of the addition.
-    pub b: Term
+    pub b: Term<'a>
 }
 
 /// A literal.

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -33,32 +33,32 @@
 
 /// A term.
 #[derive(Debug, PartialEq)]
-pub struct Term<'a> {
+pub struct Term {
     /// The term value.
-    pub t: Literal<'a>
+    pub t: Literal
 }
 
 /// A binding of a value to a variable.
 #[derive(Debug, PartialEq)]
-pub struct Binding<'a> {
+pub struct Binding {
     ///
     pub variable: String,
     /// 
-    pub expression: Term<'a>
+    pub expression: Term
 }
 
 /// An addition of two terms.
 #[derive(Debug, PartialEq)]
-pub struct Addition<'a> {
+pub struct Addition {
     /// The left-hand side of the addition.
-    pub a: Term<'a>,
+    pub a: Term,
     /// The right-hand side of the addition.
-    pub b: Term<'a>
+    pub b: Term
 }
 
 /// A literal.
 #[derive(Debug, PartialEq)]
-pub enum Literal<'a> {
+pub enum Literal {
     /// The null value.
     Null,
     /// A boolean.
@@ -70,5 +70,5 @@ pub enum Literal<'a> {
     /// A string.
     String(Vec<u8>),
     /// An identifier.
-    Identifier(&'a [u8])
+    Identifier(Vec<u8>)
 }

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -68,7 +68,9 @@ pub enum Literal {
     /// A real, for instance an exponential number.
     Real(f64),
     /// A string.
-    String(Vec<u8>),
-    /// An identifier.
-    Identifier(Vec<u8>)
+    String(Vec<u8>)
 }
+
+/// An identifier represents any “entity name”.
+#[derive(Debug, PartialEq)]
+pub struct Identifier<'a>(pub &'a [u8]);

--- a/source/rules/expressions.rs
+++ b/source/rules/expressions.rs
@@ -57,7 +57,7 @@ mod tests {
         assert_eq!(
             expr(b"1+2"),
             Done(
-                &b""[..], ast::Addition { a: ast::Term { t: 1 }, b: ast::Term { t: 2 } }
+                &b""[..], ast::Addition { a: ast::Term { t: ast::Literal::Integer(1) }, b: ast::Term { t: ast::Literal::Integer(2) } }
             )
         );
     }

--- a/source/rules/identifier.rs
+++ b/source/rules/identifier.rs
@@ -1,0 +1,96 @@
+// Tagua VM
+//
+//
+// New BSD License
+//
+// Copyright © 2016-2016, Ivan Enderlin.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the Hoa nor the names of its contributors may be
+//       used to endorse or promote products derived from this software without
+//       specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//! The identifier rule.
+//!
+//! The identifier rule as described by the PHP Language Specification in The
+//! [Lexical Structure chapter, Names
+//! section](https://github.com/php/php-langspec/blob/master/spec/09-lexical-structure.md#names).
+
+use super::super::ast::Identifier;
+
+named!(
+    pub identifier<Identifier>,
+    map_res!(
+        re_bytes_find_static!(r"^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*"),
+        identifier_mapper
+    )
+);
+
+fn identifier_mapper(string: &[u8]) -> Result<Identifier, ()> {
+    Ok(Identifier(string))
+}
+
+
+#[cfg(test)]
+mod tests {
+    use nom::IResult::{Done, Error};
+    use nom::{Err, ErrorKind};
+    use super::identifier;
+    use super::super::super::ast::Identifier;
+
+    #[test]
+    fn case_identifier() {
+        assert_eq!(identifier(b"_fooBar42"), Done(&b""[..], Identifier(&b"_fooBar42"[..])));
+    }
+
+    #[test]
+    fn case_identifier_shortest() {
+        assert_eq!(identifier(b"x"), Done(&b""[..], Identifier(&b"x"[..])));
+    }
+
+    #[test]
+    fn case_identifier_only_head() {
+        assert_eq!(identifier(b"aB_\x80"), Done(&b""[..], Identifier(&b"aB_\x80"[..])));
+    }
+
+    #[test]
+    fn case_identifier_head_and_tail() {
+        assert_eq!(identifier(b"aB_\x80aB7\xff"), Done(&b""[..], Identifier(&b"aB_\x80aB7\xff"[..])));
+    }
+
+    #[test]
+    fn case_identifier_copyright() {
+        // © = 0xa9
+        assert_eq!(identifier(b"\xa9"), Done(&b""[..], Identifier(&b"\xa9"[..])));
+    }
+
+    #[test]
+    fn case_identifier_non_breaking_space() {
+        //   = 0xa0
+        assert_eq!(identifier(b"\xa0"), Done(&b""[..], Identifier(&b"\xa0"[..])));
+    }
+
+    #[test]
+    fn case_identifier_invalid() {
+        assert_eq!(identifier(b"0x"), Error(Err::Code(ErrorKind::RegexpFind)));
+    }
+}

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -286,8 +286,13 @@ fn string_nowdoc(input: &[u8]) -> IResult<&[u8], Literal> {
 }
 
 named!(
-    pub identifier,
-    re_bytes_find_static!(r"^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*")
+    pub identifier<Literal>,
+    map_res!(
+        re_bytes_find_static!(r"^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*"),
+        |string: &[u8]| -> Result<Literal, ()> {
+            Ok(Literal::Identifier(string.to_vec()))
+        }
+    )
 );
 
 
@@ -645,34 +650,34 @@ mod tests {
 
     #[test]
     fn case_identifier() {
-        assert_eq!(identifier(b"_fooBar42"), Done(&b""[..], &b"_fooBar42"[..]));
+        assert_eq!(identifier(b"_fooBar42"), Done(&b""[..], Literal::Identifier(b"_fooBar42".to_vec())));
     }
 
     #[test]
     fn case_identifier_shortest() {
-        assert_eq!(identifier(b"x"), Done(&b""[..], &b"x"[..]));
+        assert_eq!(identifier(b"x"), Done(&b""[..], Literal::Identifier(b"x".to_vec())));
     }
 
     #[test]
     fn case_identifier_only_head() {
-        assert_eq!(identifier(b"aB_\x80"), Done(&b""[..], &b"aB_\x80"[..]));
+        assert_eq!(identifier(b"aB_\x80"), Done(&b""[..], Literal::Identifier(b"aB_\x80".to_vec())));
     }
 
     #[test]
     fn case_identifier_head_and_tail() {
-        assert_eq!(identifier(b"aB_\x80aB7\xff"), Done(&b""[..], &b"aB_\x80aB7\xff"[..]));
+        assert_eq!(identifier(b"aB_\x80aB7\xff"), Done(&b""[..], Literal::Identifier(b"aB_\x80aB7\xff".to_vec())));
     }
 
     #[test]
     fn case_identifier_copyright() {
         // © = 0xa9
-        assert_eq!(identifier(b"\xa9"), Done(&b""[..], &b"\xa9"[..]));
+        assert_eq!(identifier(b"\xa9"), Done(&b""[..], Literal::Identifier(b"\xa9".to_vec())));
     }
 
     #[test]
     fn case_identifier_non_breaking_space() {
         //   = 0xa0
-        assert_eq!(identifier(b"\xa0"), Done(&b""[..], &b"\xa0"[..]));
+        assert_eq!(identifier(b"\xa0"), Done(&b""[..], Literal::Identifier(b"\xa0".to_vec())));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -150,11 +150,17 @@ named!(
 );
 
 named!(
-    pub exponential<f64>,
+    pub exponential<Literal>,
     map_res!(
         re_bytes_find_static!(r"^([0-9]*\.[0-9]+|[0-9]+\.)([eE][+-]?[0-9]+)?"),
         |string: &[u8]| {
-            f64::from_str(unsafe { str::from_utf8_unchecked(string) })
+            f64
+                ::from_str(unsafe { str::from_utf8_unchecked(string) })
+                .and_then(
+                    |exponential| {
+                        Ok(Literal::Float(exponential))
+                    }
+                )
         }
     )
 );
@@ -392,57 +398,57 @@ mod tests {
 
     #[test]
     fn case_exponential() {
-        assert_eq!(exponential(b"123.456e+78"), Done(&b""[..], 123.456e78f64));
+        assert_eq!(exponential(b"123.456e+78"), Done(&b""[..], Literal::Float(123.456e78f64)));
     }
 
     #[test]
     fn case_exponential_only_with_rational_and_fractional_part() {
-        assert_eq!(exponential(b"123.456"), Done(&b""[..], 123.456f64));
+        assert_eq!(exponential(b"123.456"), Done(&b""[..], Literal::Float(123.456f64)));
     }
 
     #[test]
     fn case_exponential_only_with_rational_part() {
-        assert_eq!(exponential(b"123."), Done(&b""[..], 123.0f64));
+        assert_eq!(exponential(b"123."), Done(&b""[..], Literal::Float(123.0f64)));
     }
 
     #[test]
     fn case_exponential_only_with_fractional_part() {
-        assert_eq!(exponential(b".456"), Done(&b""[..], 0.456f64));
+        assert_eq!(exponential(b".456"), Done(&b""[..], Literal::Float(0.456f64)));
     }
 
     #[test]
     fn case_exponential_only_with_rational_and_exponent_part_with_lowercase_e() {
-        assert_eq!(exponential(b"123.e78"), Done(&b""[..], 123e78f64));
+        assert_eq!(exponential(b"123.e78"), Done(&b""[..], Literal::Float(123e78f64)));
     }
 
     #[test]
     fn case_exponential_only_with_rational_and_exponent_part_with_uppercase_e() {
-        assert_eq!(exponential(b"123.E78"), Done(&b""[..], 123e78f64));
+        assert_eq!(exponential(b"123.E78"), Done(&b""[..], Literal::Float(123e78f64)));
     }
 
     #[test]
     fn case_exponential_only_with_rational_and_unsigned_exponent_part() {
-        assert_eq!(exponential(b"123.e78"), Done(&b""[..], 123e78f64));
+        assert_eq!(exponential(b"123.e78"), Done(&b""[..], Literal::Float(123e78f64)));
     }
 
     #[test]
     fn case_exponential_only_with_rational_and_positive_exponent_part() {
-        assert_eq!(exponential(b"123.e+78"), Done(&b""[..], 123e78f64));
+        assert_eq!(exponential(b"123.e+78"), Done(&b""[..], Literal::Float(123e78f64)));
     }
 
     #[test]
     fn case_exponential_only_with_rational_and_negative_exponent_part() {
-        assert_eq!(exponential(b"123.e-78"), Done(&b""[..], 123e-78f64));
+        assert_eq!(exponential(b"123.e-78"), Done(&b""[..], Literal::Float(123e-78f64)));
     }
 
     #[test]
     fn case_exponential_only_with_rational_and_negative_zero_exponent_part() {
-        assert_eq!(exponential(b"123.e-0"), Done(&b""[..], 123f64));
+        assert_eq!(exponential(b"123.e-0"), Done(&b""[..], Literal::Float(123f64)));
     }
 
     #[test]
     fn case_exponential_missing_exponent_part() {
-        assert_eq!(exponential(b".7e"), Done(&b"e"[..], 0.7f64));
+        assert_eq!(exponential(b".7e"), Done(&b"e"[..], Literal::Float(0.7f64)));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -306,16 +306,6 @@ fn string_nowdoc(input: &[u8]) -> IResult<&[u8], Literal> {
     IResult::Error(Err::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32)))
 }
 
-named!(
-    pub identifier<Literal>,
-    map_res!(
-        re_bytes_find_static!(r"^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*"),
-        |string: &[u8]| -> Result<Literal, ()> {
-            Ok(Literal::Identifier(string.to_vec()))
-        }
-    )
-);
-
 
 #[cfg(test)]
 mod tests {
@@ -329,7 +319,6 @@ mod tests {
         decimal,
         exponential,
         hexadecimal,
-        identifier,
         integer,
         literal,
         null,
@@ -830,42 +819,5 @@ mod tests {
         assert_eq!(string_nowdoc(input), Error(Err::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
         assert_eq!(literal(input), output);
-    }
-
-    #[test]
-    fn case_identifier() {
-        assert_eq!(identifier(b"_fooBar42"), Done(&b""[..], Literal::Identifier(b"_fooBar42".to_vec())));
-    }
-
-    #[test]
-    fn case_identifier_shortest() {
-        assert_eq!(identifier(b"x"), Done(&b""[..], Literal::Identifier(b"x".to_vec())));
-    }
-
-    #[test]
-    fn case_identifier_only_head() {
-        assert_eq!(identifier(b"aB_\x80"), Done(&b""[..], Literal::Identifier(b"aB_\x80".to_vec())));
-    }
-
-    #[test]
-    fn case_identifier_head_and_tail() {
-        assert_eq!(identifier(b"aB_\x80aB7\xff"), Done(&b""[..], Literal::Identifier(b"aB_\x80aB7\xff".to_vec())));
-    }
-
-    #[test]
-    fn case_identifier_copyright() {
-        // © = 0xa9
-        assert_eq!(identifier(b"\xa9"), Done(&b""[..], Literal::Identifier(b"\xa9".to_vec())));
-    }
-
-    #[test]
-    fn case_identifier_non_breaking_space() {
-        //   = 0xa0
-        assert_eq!(identifier(b"\xa0"), Done(&b""[..], Literal::Identifier(b"\xa0".to_vec())));
-    }
-
-    #[test]
-    fn case_identifier_invalid() {
-        assert_eq!(identifier(b"0x"), Error(Err::Code(ErrorKind::RegexpFind)));
     }
 }

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -42,15 +42,16 @@ use nom::{
     hex_digit,
     oct_digit
 };
-use std::str;
 use std::str::FromStr;
+use std::str;
+use super::super::ast::Literal;
 
 named!(
-    pub null< Option<()> >,
+    pub null<Literal>,
     map_res!(
         tag!("null"),
-        |_: &[u8]| -> Result<Option<()>, ()> {
-            Ok(None)
+        |_: &[u8]| -> Result<Literal, ()> {
+            Ok(Literal::Null)
         }
     )
 );
@@ -266,6 +267,7 @@ named!(
 mod tests {
     use nom::IResult::{Done, Error};
     use nom::{Err, ErrorKind};
+    use super::super::super::ast::Literal;
     use super::{
         StringError,
         binary,
@@ -283,7 +285,7 @@ mod tests {
 
     #[test]
     fn case_null() {
-        assert_eq!(null(b"null"), Done(&b""[..], None));
+        assert_eq!(null(b"null"), Done(&b""[..], Literal::Null));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -488,7 +488,7 @@ mod tests {
     #[test]
     fn case_invalid_hexadecimal_not_in_base() {
         let input  = b"0xg";
-        let output =Error(Err::Position(ErrorKind::Alt, &b"0xg"[..]));
+        let output = Error(Err::Position(ErrorKind::Alt, &b"0xg"[..]));
 
         assert_eq!(hexadecimal(input), Error(Err::Position(ErrorKind::HexDigit, &b"g"[..])));
         assert_eq!(integer(input), output);

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -77,14 +77,15 @@ named!(
             )
         ),
         |string: &[u8]| {
-            u64::from_str_radix(
-                unsafe { str::from_utf8_unchecked(string) },
-                2
-            ).and_then(
-                |binary| {
-                    Ok(Literal::Integer(binary))
-               }
-            )
+            u64
+                ::from_str_radix(
+                    unsafe { str::from_utf8_unchecked(string) },
+                    2
+                ).and_then(
+                    |binary| {
+                        Ok(Literal::Integer(binary))
+                   }
+                )
         }
     )
 );
@@ -94,14 +95,15 @@ named!(
     map_res!(
         preceded!(tag!("0"), oct_digit),
         |string: &[u8]| {
-            u64::from_str_radix(
-                unsafe { str::from_utf8_unchecked(string) },
-                8
-            ).and_then(
-                |octal| {
-                    Ok(Literal::Integer(octal))
-                }
-            )
+            u64
+                ::from_str_radix(
+                    unsafe { str::from_utf8_unchecked(string) },
+                    8
+                ).and_then(
+                    |octal| {
+                        Ok(Literal::Integer(octal))
+                    }
+                )
         }
     )
 );

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -125,7 +125,7 @@ named!(
 );
 
 named!(
-    pub hexadecimal<u64>,
+    pub hexadecimal<Literal>,
     map_res!(
         preceded!(
             tag!("0"),
@@ -135,10 +135,16 @@ named!(
             )
         ),
         |string: &[u8]| {
-            u64::from_str_radix(
-                unsafe { str::from_utf8_unchecked(string) },
-                16
-            )
+            u64
+                ::from_str_radix(
+                    unsafe { str::from_utf8_unchecked(string) },
+                    16
+                )
+                .and_then(
+                    |hexadecimal| {
+                        Ok(Literal::Integer(hexadecimal))
+                    }
+                )
         }
     )
 );
@@ -361,17 +367,17 @@ mod tests {
 
     #[test]
     fn case_hexadecimal_lowercase_x() {
-        assert_eq!(hexadecimal(b"0x2a"), Done(&b""[..], 42u64));
+        assert_eq!(hexadecimal(b"0x2a"), Done(&b""[..], Literal::Integer(42u64)));
     }
 
     #[test]
     fn case_hexadecimal_uppercase_x() {
-        assert_eq!(hexadecimal(b"0X2a"), Done(&b""[..], 42u64));
+        assert_eq!(hexadecimal(b"0X2a"), Done(&b""[..], Literal::Integer(42u64)));
     }
 
     #[test]
     fn case_hexadecimal_uppercase_alpha() {
-        assert_eq!(hexadecimal(b"0x2A"), Done(&b""[..], 42u64));
+        assert_eq!(hexadecimal(b"0x2A"), Done(&b""[..], Literal::Integer(42u64)));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -67,6 +67,16 @@ named!(
 );
 
 named!(
+    pub integer<Literal>,
+    alt!(
+        binary
+      | octal
+      | decimal
+      | hexadecimal
+    )
+);
+
+named!(
     pub binary<Literal>,
     map_res!(
         preceded!(
@@ -309,11 +319,12 @@ mod tests {
         exponential,
         hexadecimal,
         identifier,
+        integer,
         null,
         octal,
         string,
-        string_single_quoted,
-        string_nowdoc
+        string_nowdoc,
+        string_single_quoted
     };
 
     #[test]
@@ -333,72 +344,123 @@ mod tests {
 
     #[test]
     fn case_binary_lowercase_b() {
-        assert_eq!(binary(b"0b101010"), Done(&b""[..], Literal::Integer(42u64)));
+        let input  = b"0b101010";
+        let output = Done(&b""[..], Literal::Integer(42u64));
+
+        assert_eq!(binary(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_binary_uppercase_b() {
-        assert_eq!(binary(b"0B101010"), Done(&b""[..], Literal::Integer(42u64)));
+        let input  = b"0B101010";
+        let output = Done(&b""[..], Literal::Integer(42u64));
+
+        assert_eq!(binary(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_invalid_binary_no_number() {
-        assert_eq!(binary(b"0b"), Error(Err::Position(ErrorKind::MapRes, &b"0b"[..])));
+        let input = b"0b";
+
+        assert_eq!(binary(input), Error(Err::Position(ErrorKind::MapRes, &b"0b"[..])));
+        assert_eq!(integer(input), Error(Err::Position(ErrorKind::Alt, &b"0b"[..])));
     }
 
     #[test]
     fn case_octal() {
-        assert_eq!(octal(b"052"), Done(&b""[..], Literal::Integer(42u64)));
+        let input  = b"052";
+        let output = Done(&b""[..], Literal::Integer(42u64));
+
+        assert_eq!(octal(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_invalid_octal_not_starting_by_zero() {
-        assert_eq!(octal(b"7"), Error(Err::Position(ErrorKind::Tag, &b"7"[..])));
+        let input  = b"7";
+
+        assert_eq!(octal(input), Error(Err::Position(ErrorKind::Tag, &b"7"[..])));
+        assert_eq!(integer(input), Done(&b""[..], Literal::Integer(7u64)));
     }
 
     #[test]
     fn case_invalid_octal_not_in_base() {
-        assert_eq!(octal(b"8"), Error(Err::Position(ErrorKind::Tag, &b"8"[..])));
+        let input = b"8";
+
+        assert_eq!(octal(input), Error(Err::Position(ErrorKind::Tag, &b"8"[..])));
+        assert_eq!(integer(input), Done(&b""[..], Literal::Integer(8)));
     }
 
     #[test]
     fn case_decimal_one_digit() {
-        assert_eq!(decimal(b"7"), Done(&b""[..], Literal::Integer(7u64)));
+        let input  = b"7";
+        let output = Done(&b""[..], Literal::Integer(7u64));
+
+        assert_eq!(decimal(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_decimal_many_digits() {
-        assert_eq!(decimal(b"42"), Done(&b""[..], Literal::Integer(42u64)));
+        let input  = b"42";
+        let output = Done(&b""[..], Literal::Integer(42u64));
+
+        assert_eq!(decimal(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_decimal_plus() {
-        assert_eq!(decimal(b"42+"), Done(&b"+"[..], Literal::Integer(42u64)));
+        let input  = b"42+";
+        let output = Done(&b"+"[..], Literal::Integer(42u64));
+
+        assert_eq!(decimal(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_hexadecimal_lowercase_x() {
-        assert_eq!(hexadecimal(b"0x2a"), Done(&b""[..], Literal::Integer(42u64)));
+        let input  = b"0x2a";
+        let output = Done(&b""[..], Literal::Integer(42u64));
+
+        assert_eq!(hexadecimal(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_hexadecimal_uppercase_x() {
-        assert_eq!(hexadecimal(b"0X2a"), Done(&b""[..], Literal::Integer(42u64)));
+        let input  = b"0X2a";
+        let output = Done(&b""[..], Literal::Integer(42u64));
+
+        assert_eq!(hexadecimal(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_hexadecimal_uppercase_alpha() {
-        assert_eq!(hexadecimal(b"0x2A"), Done(&b""[..], Literal::Integer(42u64)));
+        let input  = b"0x2A";
+        let output = Done(&b""[..], Literal::Integer(42u64));
+
+        assert_eq!(hexadecimal(input), output);
+        assert_eq!(integer(input), output);
     }
 
     #[test]
     fn case_invalid_hexadecimal_no_number() {
-        assert_eq!(hexadecimal(b"0x"), Error(Err::Position(ErrorKind::HexDigit, &b""[..])));
+        let input = b"0x";
+
+        assert_eq!(hexadecimal(input), Error(Err::Position(ErrorKind::HexDigit, &b""[..])));
+        assert_eq!(integer(input), Error(Err::Position(ErrorKind::Alt, &b"0x"[..])));
     }
 
     #[test]
     fn case_invalid_hexadecimal_not_in_base() {
-        assert_eq!(hexadecimal(b"0xg"), Error(Err::Position(ErrorKind::HexDigit, &b"g"[..])));
+        let input = b"0xg";
+
+        assert_eq!(hexadecimal(input), Error(Err::Position(ErrorKind::HexDigit, &b"g"[..])));
+        assert_eq!(integer(input), Error(Err::Position(ErrorKind::Alt, &b"0xg"[..])));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -90,13 +90,17 @@ named!(
 );
 
 named!(
-    pub octal<u64>,
+    pub octal<Literal>,
     map_res!(
         preceded!(tag!("0"), oct_digit),
         |string: &[u8]| {
             u64::from_str_radix(
                 unsafe { str::from_utf8_unchecked(string) },
                 8
+            ).and_then(
+                |octal| {
+                    Ok(Literal::Integer(octal))
+                }
             )
         }
     )
@@ -319,7 +323,7 @@ mod tests {
 
     #[test]
     fn case_octal() {
-        assert_eq!(octal(b"052"), Done(&b""[..], 42u64));
+        assert_eq!(octal(b"052"), Done(&b""[..], Literal::Integer(42u64)));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -109,11 +109,17 @@ named!(
 );
 
 named!(
-    pub decimal<u64>,
+    pub decimal<Literal>,
     map_res!(
         re_bytes_find_static!(r"^[1-9][0-9]*"),
         |string: &[u8]| {
-            u64::from_str(unsafe { str::from_utf8_unchecked(string) })
+            u64
+                ::from_str(unsafe { str::from_utf8_unchecked(string) })
+                .and_then(
+                    |decimal| {
+                        Ok(Literal::Integer(decimal))
+                    }
+                )
         }
     )
 );
@@ -340,17 +346,17 @@ mod tests {
 
     #[test]
     fn case_decimal_one_digit() {
-        assert_eq!(decimal(b"7"), Done(&b""[..], 7u64));
+        assert_eq!(decimal(b"7"), Done(&b""[..], Literal::Integer(7u64)));
     }
 
     #[test]
     fn case_decimal_many_digits() {
-        assert_eq!(decimal(b"42"), Done(&b""[..], 42u64));
+        assert_eq!(decimal(b"42"), Done(&b""[..], Literal::Integer(42u64)));
     }
 
     #[test]
     fn case_decimal_plus() {
-        assert_eq!(decimal(b"42+"), Done(&b"+"[..], 42u64));
+        assert_eq!(decimal(b"42+"), Done(&b"+"[..], Literal::Integer(42u64)));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -57,11 +57,11 @@ named!(
 );
 
 named!(
-    pub boolean<bool>,
+    pub boolean<Literal>,
     map_res!(
         alt!(tag!("true") | tag!("false")),
-        |string: &[u8]| -> Result<bool, ()> {
-            Ok(string[0] == 't' as u8)
+        |string: &[u8]| -> Result<Literal, ()> {
+            Ok(Literal::Boolean(string[0] == 't' as u8))
         }
     )
 );
@@ -290,12 +290,12 @@ mod tests {
 
     #[test]
     fn case_boolean_true() {
-        assert_eq!(boolean(b"true"), Done(&b""[..], true));
+        assert_eq!(boolean(b"true"), Done(&b""[..], Literal::Boolean(true)));
     }
 
     #[test]
     fn case_boolean_false() {
-        assert_eq!(boolean(b"false"), Done(&b""[..], false));
+        assert_eq!(boolean(b"false"), Done(&b""[..], Literal::Boolean(false)));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -179,7 +179,7 @@ named!(
                 ::from_str(unsafe { str::from_utf8_unchecked(string) })
                 .and_then(
                     |exponential| {
-                        Ok(Literal::Float(exponential))
+                        Ok(Literal::Real(exponential))
                     }
                 )
         }
@@ -508,7 +508,7 @@ mod tests {
     #[test]
     fn case_exponential() {
         let input  = b"123.456e+78";
-        let output = Done(&b""[..], Literal::Float(123.456e78f64));
+        let output = Done(&b""[..], Literal::Real(123.456e78f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -517,7 +517,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_rational_and_fractional_part() {
         let input  = b"123.456";
-        let output = Done(&b""[..], Literal::Float(123.456f64));
+        let output = Done(&b""[..], Literal::Real(123.456f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -526,7 +526,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_rational_part() {
         let input  = b"123.";
-        let output = Done(&b""[..], Literal::Float(123.0f64));
+        let output = Done(&b""[..], Literal::Real(123.0f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -535,7 +535,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_fractional_part() {
         let input  = b".456";
-        let output = Done(&b""[..], Literal::Float(0.456f64));
+        let output = Done(&b""[..], Literal::Real(0.456f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -544,7 +544,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_rational_and_exponent_part_with_lowercase_e() {
         let input  = b"123.e78";
-        let output = Done(&b""[..], Literal::Float(123e78f64));
+        let output = Done(&b""[..], Literal::Real(123e78f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_rational_and_exponent_part_with_uppercase_e() {
         let input  = b"123.E78";
-        let output = Done(&b""[..], Literal::Float(123e78f64));
+        let output = Done(&b""[..], Literal::Real(123e78f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -562,7 +562,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_rational_and_unsigned_exponent_part() {
         let input  = b"123.e78";
-        let output = Done(&b""[..], Literal::Float(123e78f64));
+        let output = Done(&b""[..], Literal::Real(123e78f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -571,7 +571,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_rational_and_positive_exponent_part() {
         let input  = b"123.e+78";
-        let output = Done(&b""[..], Literal::Float(123e78f64));
+        let output = Done(&b""[..], Literal::Real(123e78f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -580,7 +580,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_rational_and_negative_exponent_part() {
         let input  = b"123.e-78";
-        let output = Done(&b""[..], Literal::Float(123e-78f64));
+        let output = Done(&b""[..], Literal::Real(123e-78f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -589,7 +589,7 @@ mod tests {
     #[test]
     fn case_exponential_only_with_rational_and_negative_zero_exponent_part() {
         let input  = b"123.e-0";
-        let output = Done(&b""[..], Literal::Float(123f64));
+        let output = Done(&b""[..], Literal::Real(123f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -598,7 +598,7 @@ mod tests {
     #[test]
     fn case_exponential_missing_exponent_part() {
         let input  = b".7e";
-        let output = Done(&b"e"[..], Literal::Float(0.7f64));
+        let output = Done(&b"e"[..], Literal::Real(0.7f64));
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -67,7 +67,7 @@ named!(
 );
 
 named!(
-    pub binary<u64>,
+    pub binary<Literal>,
     map_res!(
         preceded!(
             tag!("0"),
@@ -80,6 +80,10 @@ named!(
             u64::from_str_radix(
                 unsafe { str::from_utf8_unchecked(string) },
                 2
+            ).and_then(
+                |binary| {
+                    Ok(Literal::Integer(binary))
+               }
             )
         }
     )
@@ -300,12 +304,12 @@ mod tests {
 
     #[test]
     fn case_binary_lowercase_b() {
-        assert_eq!(binary(b"0b101010"), Done(&b""[..], 42u64));
+        assert_eq!(binary(b"0b101010"), Done(&b""[..], Literal::Integer(42u64)));
     }
 
     #[test]
     fn case_binary_uppercase_b() {
-        assert_eq!(binary(b"0B101010"), Done(&b""[..], 42u64));
+        assert_eq!(binary(b"0B101010"), Done(&b""[..], Literal::Integer(42u64)));
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -377,11 +377,12 @@ mod tests {
 
     #[test]
     fn case_invalid_binary_no_number() {
-        let input = b"0b";
+        let input  = b"0b";
+        let output = Error(Err::Position(ErrorKind::Alt, &b"0b"[..]));
 
         assert_eq!(binary(input), Error(Err::Position(ErrorKind::MapRes, &b"0b"[..])));
-        assert_eq!(integer(input), Error(Err::Position(ErrorKind::Alt, &b"0b"[..])));
-        assert_eq!(literal(input), Error(Err::Position(ErrorKind::Alt, &b"0b"[..])));
+        assert_eq!(integer(input), output);
+        assert_eq!(literal(input), output);
     }
 
     #[test]

--- a/source/rules/mod.rs
+++ b/source/rules/mod.rs
@@ -35,6 +35,7 @@
 
 pub mod comments;
 pub mod expressions;
+pub mod identifier;
 pub mod literals;
 
 use super::ast;

--- a/source/rules/mod.rs
+++ b/source/rules/mod.rs
@@ -59,7 +59,7 @@ mod tests {
         assert_eq!(
             expr(b"1+2"),
             Done(
-                &b""[..], ast::Addition { a: ast::Term { t: 1 }, b: ast::Term { t: 2 } }
+                &b""[..], ast::Addition { a: ast::Term { t: ast::Literal::Integer(1) }, b: ast::Term { t: ast::Literal::Integer(2) } }
             )
         );
     }


### PR DESCRIPTION
Address https://github.com/tagua-vm/parser/issues/5.
### Specification

https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#general-3
### Progression
- [x] Create the `Literal` enum in the AST (because all literal rules are returning a different type, we cannot work with that),
- [x] The `null` rule must computes a `Literal`,
- [x] The `boolean` rule must computes a `Literal`,
- [x] The `binary` rule must computes a `Literal`,
- [x] The `octal` rule must computes a `Literal`,
- [x] The `decimal` rule must computes a `Literal`,
- [x] The `hexadecimal` rule must computes a `Literal`,
- [x] The `exponential` rule must computes a `Literal`,
- [x] The `string` rule must computes a `Literal`,
- [x] The `identifier` rule must computes a `Literal`,
- [x] Create the `integer` rule,
- [x] Create the `floating` rule,
- [x] Create the `literal` rule.
