### PR TITLE
Token: Add `NAMESPACE_SEPARATOR`

### DIFF
--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -411,6 +411,10 @@ token!(
     "The `NAMESPACE` token.\n\nRepresent the namespace declaration operator, e.g. `namespace N;`."
 );
 token!(
+    pub NAMESPACE_SEPARATOR: "\\";
+    "The `NAMESPACE_SEPARATOR` token.\n\nRepresent the namespace separator, e.g. `A\\B\\C`."
+);
+token!(
     pub NEW: "new";
     "The `NEW` token.\n\nRepresent the instanciation operator, e.g. `new C()`."
 );


### PR DESCRIPTION
Address #22 and #8.
#### Specification

https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#operators-and-punctuators

Since our PR on the specification, https://github.com/php/php-langspec/pull/160, the new `\` token has been added, https://github.com/php/php-langspec/commit/4a0bcfb3c75f08320a05596d3658f6976890c5b9, and it was missing in our tokens list.
#### Progression
- [x] `\`.
