### PR TITLE
Build: Remove “vm” from the project name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,8 @@ codegen-units    = 1
 
 [dependencies]
 lazy_static = "~0.1"
-nom = {git = "https://github.com/Geal/nom", rev = "master", "features" = ["regexp", "regexp_macros"]}
 regex = "~0.1"
+
+[dependencies.nom]
+version = "^1.2.3"
+features = ["regexp", "regexp_macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name        = "tagua-vm-parser"
+name        = "tagua-parser"
 version     = "0.0.1"
 authors     = ["Ivan Enderlin <ivan.enderlin@hoa-project.net>"]
 repository  = "https://github.com/tagua-vm/parser"
@@ -9,7 +9,7 @@ keywords    = ["php", "virtual machine", "parser", "lexical", "syntactic", "anal
 license     = "BSD-3-Clause"
 
 [lib]
-name    = "taguavm_parser"
+name    = "tagua_parser"
 path    = "source/lib.rs"
 test    = true
 doctest = true

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ following command:
 
 ```sh
 $ cargo doc
-$ open target/doc/taguavm_parser/index.html
+$ open target/doc/tagua_parser/index.html
 ```
 
 To get help on IRC, please join the official [`#taguavm` channel on

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -80,9 +80,9 @@ pub enum Literal {
 /// # #[macro_use]
 /// # extern crate nom;
 /// use nom::IResult::Done;
-/// # extern crate taguavm_parser;
-/// use taguavm_parser::rules::tokens::variable;
-/// use taguavm_parser::ast::Variable;
+/// # extern crate tagua_parser;
+/// use tagua_parser::rules::tokens::variable;
+/// use tagua_parser::ast::Variable;
 ///
 /// # fn main () {
 /// assert_eq!(
@@ -106,9 +106,9 @@ pub enum Name<'a> {
     /// # #[macro_use]
     /// # extern crate nom;
     /// use nom::IResult::Done;
-    /// # extern crate taguavm_parser;
-    /// use taguavm_parser::rules::tokens::qualified_name;
-    /// use taguavm_parser::ast::Name;
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::ast::Name;
     ///
     /// # fn main () {
     /// assert_eq!(
@@ -128,9 +128,9 @@ pub enum Name<'a> {
     /// # #[macro_use]
     /// # extern crate nom;
     /// use nom::IResult::Done;
-    /// # extern crate taguavm_parser;
-    /// use taguavm_parser::rules::tokens::qualified_name;
-    /// use taguavm_parser::ast::Name;
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::ast::Name;
     ///
     /// # fn main () {
     /// assert_eq!(
@@ -150,9 +150,9 @@ pub enum Name<'a> {
     /// # #[macro_use]
     /// # extern crate nom;
     /// use nom::IResult::Done;
-    /// # extern crate taguavm_parser;
-    /// use taguavm_parser::rules::tokens::qualified_name;
-    /// use taguavm_parser::ast::Name;
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::ast::Name;
     ///
     /// # fn main () {
     /// assert_eq!(
@@ -173,9 +173,9 @@ pub enum Name<'a> {
     /// # #[macro_use]
     /// # extern crate nom;
     /// use nom::IResult::Done;
-    /// # extern crate taguavm_parser;
-    /// use taguavm_parser::rules::tokens::qualified_name;
-    /// use taguavm_parser::ast::Name;
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::ast::Name;
     ///
     /// # fn main () {
     /// assert_eq!(

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -75,7 +75,7 @@ pub mod tokens;
 /// # Examples
 ///
 /// ```
-/// use taguavm_parser as parser;
+/// use tagua_parser as parser;
 ///
 /// let expression = b"1+2";
 /// parser::parse(&expression[..]);

--- a/source/macros.rs
+++ b/source/macros.rs
@@ -168,7 +168,7 @@ macro_rules! first(
 /// # extern crate nom;
 /// use nom::IResult::Done;
 /// # #[macro_use]
-/// # extern crate taguavm_parser;
+/// # extern crate tagua_parser;
 ///
 /// # fn main() {
 /// named!(
@@ -231,8 +231,8 @@ macro_rules! itag(
 /// # extern crate nom;
 /// use nom::IResult::Done;
 /// # #[macro_use]
-/// # extern crate taguavm_parser;
-/// use taguavm_parser::tokens;
+/// # extern crate tagua_parser;
+/// use tagua_parser::tokens;
 ///
 /// # fn main() {
 /// named!(

--- a/source/macros.rs
+++ b/source/macros.rs
@@ -53,8 +53,8 @@ pub enum ErrorKindCustom {
 /// use nom::IResult::{Done, Error};
 /// use nom::{Err, ErrorKind};
 /// # #[macro_use]
-/// # extern crate taguavm_parser;
-/// use taguavm_parser::macros::ErrorKindCustom;
+/// # extern crate tagua_parser;
+/// use tagua_parser::macros::ErrorKindCustom;
 ///
 /// # fn main() {
 /// named!(
@@ -122,7 +122,7 @@ macro_rules! exclude(
 /// # extern crate nom;
 /// use nom::IResult::Done;
 /// # #[macro_use]
-/// # extern crate taguavm_parser;
+/// # extern crate tagua_parser;
 ///
 /// # fn main() {
 /// named!(


### PR DESCRIPTION
As discussed on IRC, this PR removes the “vm” part from the project name. So it becomes: `tagua_parser` instead of `taguavm_parser`.
