### PR TITLE
Literal: `null`, `true` and `false` are case-insensitives

### DIFF
--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -60,8 +60,8 @@ named!(
 named!(
     pub null<Literal>,
     map_res!(
-        tag!("null"),
-        |_: &[u8]| -> Result<Literal, ()> {
+        itag!("null"),
+        |_| -> Result<Literal, ()> {
             Ok(Literal::Null)
         }
     )
@@ -331,6 +331,15 @@ mod tests {
     #[test]
     fn case_null() {
         let input  = b"null";
+        let output = Done(&b""[..], Literal::Null);
+
+        assert_eq!(null(input), output);
+        assert_eq!(literal(input), output);
+    }
+
+    #[test]
+    fn case_null_case_insensitive() {
+        let input  = b"NuLl";
         let output = Done(&b""[..], Literal::Null);
 
         assert_eq!(null(input), output);

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -70,7 +70,7 @@ named!(
 named!(
     pub boolean<Literal>,
     map_res!(
-        alt!(tag!("true") | tag!("false")),
+        alt!(itag!("true".as_bytes()) | itag!("false".as_bytes())),
         |string: &[u8]| -> Result<Literal, ()> {
             Ok(Literal::Boolean(string[0] == 't' as u8))
         }
@@ -356,8 +356,26 @@ mod tests {
     }
 
     #[test]
+    fn case_boolean_true_case_insensitive() {
+        let input  = b"TrUe";
+        let output = Done(&b""[..], Literal::Boolean(true));
+
+        assert_eq!(boolean(input), output);
+        assert_eq!(literal(input), output);
+    }
+
+    #[test]
     fn case_boolean_false() {
         let input  = b"false";
+        let output = Done(&b""[..], Literal::Boolean(false));
+
+        assert_eq!(boolean(input), output);
+        assert_eq!(literal(input), output);
+    }
+
+    #[test]
+    fn case_boolean_false_case_insensitive() {
+        let input  = b"FaLsE";
         let output = Done(&b""[..], Literal::Boolean(false));
 
         assert_eq!(boolean(input), output);


### PR DESCRIPTION
Fix #25.
#### Progression
- [x] `null`
- [x] `true`,
- [x] `false`.
