### PR TITLE
Literal: Check `Literal::Integer` at limits and when overflowing

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -109,7 +109,7 @@ pub enum Literal {
     /// use tagua_parser::ast::Literal;
     ///
     /// # fn main () {
-    /// let output = Done(&b""[..], Literal::Integer(42u64));
+    /// let output = Done(&b""[..], Literal::Integer(42i64));
     ///
     /// assert_eq!(literal(b"0b101010"), output);
     /// assert_eq!(literal(b"052"), output);
@@ -117,7 +117,7 @@ pub enum Literal {
     /// assert_eq!(literal(b"0x2a"), output);
     /// # }
     /// ```
-    Integer(u64),
+    Integer(i64),
 
     /// A real, for instance an exponential number.
     ///

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -71,8 +71,8 @@ named!(
     pub boolean<Literal>,
     map_res!(
         alt!(itag!("true".as_bytes()) | itag!("false".as_bytes())),
-        |string: &[u8]| -> Result<Literal, ()> {
-            Ok(Literal::Boolean(string[0] == 't' as u8))
+        |bytes: &[u8]| -> Result<Literal, ()> {
+            Ok(Literal::Boolean(bytes[0] == 't' as u8))
         }
     )
 );
@@ -97,12 +97,13 @@ named!(
                 is_a!("01")
             )
         ),
-        |string: &[u8]| {
+        |bytes: &[u8]| {
             i64
                 ::from_str_radix(
-                    unsafe { str::from_utf8_unchecked(string) },
+                    unsafe { str::from_utf8_unchecked(bytes) },
                     2
-                ).and_then(
+                )
+                .and_then(
                     |binary| {
                         Ok(Literal::Integer(binary))
                    }
@@ -115,12 +116,13 @@ named!(
     pub octal<Literal>,
     map_res!(
         preceded!(tag!("0"), oct_digit),
-        |string: &[u8]| {
+        |bytes: &[u8]| {
             i64
                 ::from_str_radix(
-                    unsafe { str::from_utf8_unchecked(string) },
+                    unsafe { str::from_utf8_unchecked(bytes) },
                     8
-                ).and_then(
+                )
+                .and_then(
                     |octal| {
                         Ok(Literal::Integer(octal))
                     }
@@ -155,10 +157,10 @@ named!(
                 hex_digit
             )
         ),
-        |string: &[u8]| {
+        |bytes: &[u8]| {
             i64
                 ::from_str_radix(
-                    unsafe { str::from_utf8_unchecked(string) },
+                    unsafe { str::from_utf8_unchecked(bytes) },
                     16
                 )
                 .and_then(
@@ -174,9 +176,9 @@ named!(
     pub exponential<Literal>,
     map_res!(
         re_bytes_find_static!(r"^(([0-9]*\.[0-9]+|[0-9]+\.)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)"),
-        |string: &[u8]| {
+        |bytes: &[u8]| {
             f64
-                ::from_str(unsafe { str::from_utf8_unchecked(string) })
+                ::from_str(unsafe { str::from_utf8_unchecked(bytes) })
                 .and_then(
                     |exponential| {
                         Ok(Literal::Real(exponential))

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -429,7 +429,7 @@ mod tests {
     }
 
     #[test]
-    fn case_binary_overflow() {
+    fn case_invalid_binary_overflow() {
         let input  = b"0b1000000000000000000000000000000000000000000000000000000000000000";
         let output = Error(Err::Position(ErrorKind::Alt, &input[..]));
 
@@ -479,7 +479,7 @@ mod tests {
     }
 
     #[test]
-    fn case_octal_maximum_value() {
+    fn case_octal_maximum_integer_value() {
         let input  = b"0777777777777777777777";
         let output = Done(&b""[..], Literal::Integer(!(1i64 << 63)));
 
@@ -639,9 +639,9 @@ mod tests {
     }
 
     #[test]
-    fn case_hexadecimal_maximum_value() {
+    fn case_hexadecimal_maximum_integer_value() {
         let input  = b"0x7fffffffffffffff";
-        let output = Done(&b""[..], Literal::Integer(!(1i64 << 63)));
+        let output = Done(&b""[..], Literal::Integer(::std::i64::MAX));
 
         assert_eq!(hexadecimal(input), output);
         assert_eq!(integer(input), output);

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     fn case_octal_maximum_integer_value() {
         let input  = b"0777777777777777777777";
-        let output = Done(&b""[..], Literal::Integer(!(1i64 << 63)));
+        let output = Done(&b""[..], Literal::Integer(::std::i64::MAX));
 
         assert_eq!(octal(input), output);
         assert_eq!(integer(input), output);


### PR DESCRIPTION
First, `Literal::Integer` was a `u64` which is wrong regarding the specification (https://github.com/php/php-langspec/blob/master/spec/05-types.md#the-integer-type):

> This type is binary, signed, and uses twos-complement representation for negative values. The range of values that can be stored is implementation-defined; however, the range [-2147483648, 2147483647], must be supported. This range must be finite.

Second, new test cases are added to test the limit values of integer representation (before and after overflow).

Third, only decimal will overflow to reals. The specification says:

> Certain operations on integer values produce a mathematical result that cannot be represented as an integer.
> […]
> In such cases, the computation is done as though the types of the values were float with the result having that type.

It does not mention the parsing behavior. The Zend Engine will apply the overflow from integer to real for all “number” representations, aka binary, octal, decimal and hexadecimal. However, the `f32::from_str_radix` and `f64::from_str_radix` functions have been removed from Rust std (see https://internals.rust-lang.org/t/deprecate-f-32-64-from-str-radix/2405) for good reasons I have to admit. So I consider this is an edge case and only the support for decimal overflow is added.

If a volunteer woud like to reimplement a safe and stable `from_str_radix` for `f64` (for 2, 8, 10 and 16 radices only), good! I am pretty sure it will be hard (to write and to test). If this is a very important conformance issue, let's open an issue.

Thoughts @jubianchi, @nikic?
