### PR TITLE
Internal: Introduce our own `Result` & co.

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -64,15 +64,13 @@ pub enum Literal {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
+    /// use tagua_parser::rules::literals::literal;
     ///
     /// # fn main () {
-    /// assert_eq!(literal(b"null"), Done(&b""[..], Literal::Null));
+    /// assert_eq!(literal(b"null"), Result::Done(&b""[..], Literal::Null));
     /// # }
     /// ```
     Null,
@@ -82,16 +80,14 @@ pub enum Literal {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
+    /// use tagua_parser::rules::literals::literal;
     ///
     /// # fn main () {
-    /// assert_eq!(literal(b"true"),  Done(&b""[..], Literal::Boolean(true)));
-    /// assert_eq!(literal(b"false"), Done(&b""[..], Literal::Boolean(false)));
+    /// assert_eq!(literal(b"true"),  Result::Done(&b""[..], Literal::Boolean(true)));
+    /// assert_eq!(literal(b"false"), Result::Done(&b""[..], Literal::Boolean(false)));
     /// # }
     /// ```
     Boolean(bool),
@@ -101,15 +97,13 @@ pub enum Literal {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
+    /// use tagua_parser::rules::literals::literal;
     ///
     /// # fn main () {
-    /// let output = Done(&b""[..], Literal::Integer(42u64));
+    /// let output = Result::Done(&b""[..], Literal::Integer(42u64));
     ///
     /// assert_eq!(literal(b"0b101010"), output);
     /// assert_eq!(literal(b"052"), output);
@@ -124,15 +118,13 @@ pub enum Literal {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
+    /// use tagua_parser::rules::literals::literal;
     ///
     /// # fn main () {
-    /// let output = Done(&b""[..], Literal::Real(4.2f64));
+    /// let output = Result::Done(&b""[..], Literal::Real(4.2f64));
     ///
     /// assert_eq!(literal(b"4.2"), output);
     /// assert_eq!(literal(b".42e1"), output);
@@ -146,17 +138,15 @@ pub enum Literal {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
+    /// use tagua_parser::rules::literals::literal;
     ///
     /// # fn main () {
     /// assert_eq!(
     ///     literal(b"'foo\\'bar'"),
-    ///     Done(&b""[..], Literal::String(b"foo'bar".to_vec()))
+    ///     Result::Done(&b""[..], Literal::String(b"foo'bar".to_vec()))
     /// );
     /// # }
     /// ```
@@ -169,17 +159,15 @@ pub enum Literal {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use]
-/// # extern crate nom;
-/// use nom::IResult::Done;
 /// # extern crate tagua_parser;
-/// use tagua_parser::rules::tokens::variable;
+/// use tagua_parser::Result;
 /// use tagua_parser::ast::Variable;
+/// use tagua_parser::rules::tokens::variable;
 ///
 /// # fn main () {
 /// assert_eq!(
 ///     variable(b"$foo"),
-///     Done(&b""[..], Variable(&b"foo"[..]))
+///     Result::Done(&b""[..], Variable(&b"foo"[..]))
 /// );
 /// # }
 /// ```
@@ -195,17 +183,15 @@ pub enum Name<'a> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
+    /// use tagua_parser::rules::tokens::qualified_name;
     ///
     /// # fn main () {
     /// assert_eq!(
     ///     qualified_name(b"Bar"),
-    ///     Done(&b""[..], Name::Unqualified(&b"Bar"[..]))
+    ///     Result::Done(&b""[..], Name::Unqualified(&b"Bar"[..]))
     /// );
     /// # }
     /// ```
@@ -217,17 +203,15 @@ pub enum Name<'a> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
+    /// use tagua_parser::rules::tokens::qualified_name;
     ///
     /// # fn main () {
     /// assert_eq!(
     ///     qualified_name(b"Foo\\Bar"),
-    ///     Done(&b""[..], Name::Qualified(vec![&b"Foo"[..], &b"Bar"[..]]))
+    ///     Result::Done(&b""[..], Name::Qualified(vec![&b"Foo"[..], &b"Bar"[..]]))
     /// );
     /// # }
     /// ```
@@ -239,17 +223,15 @@ pub enum Name<'a> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
+    /// use tagua_parser::rules::tokens::qualified_name;
     ///
     /// # fn main () {
     /// assert_eq!(
     ///     qualified_name(b"namespace\\Foo\\Bar"),
-    ///     Done(&b""[..], Name::RelativeQualified(vec![&b"Foo"[..], &b"Bar"[..]]))
+    ///     Result::Done(&b""[..], Name::RelativeQualified(vec![&b"Foo"[..], &b"Bar"[..]]))
     /// );
     /// # }
     /// ```
@@ -262,17 +244,15 @@ pub enum Name<'a> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate nom;
-    /// use nom::IResult::Done;
     /// # extern crate tagua_parser;
-    /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
+    /// use tagua_parser::rules::tokens::qualified_name;
     ///
     /// # fn main () {
     /// assert_eq!(
     ///     qualified_name(b"\\Foo\\Bar"),
-    ///     Done(&b""[..], Name::FullyQualified(vec![&b"Foo"[..], &b"Bar"[..]]))
+    ///     Result::Done(&b""[..], Name::FullyQualified(vec![&b"Foo"[..], &b"Bar"[..]]))
     /// );
     /// # }
     /// ```

--- a/source/internal.rs
+++ b/source/internal.rs
@@ -29,43 +29,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-//! The skip rule.
-//!
-//! The skip rule is a special rule representing all the tokens that are not
-//! required. For instance, whitespaces and comments can most of the time be
-//! skipped.
+//! Internal utilities for the parser.
 
-use super::comments::comment;
-use super::whitespaces::whitespace;
-
-named!(
-    pub skip< Vec<&[u8]> >,
-    many0!(
-        alt!(
-            comment
-          | whitespace
-        )
-    )
-);
-
-
-#[cfg(test)]
-mod tests {
-    use super::skip;
-    use super::super::super::internal::Result;
-
-    #[test]
-    fn case_skip_comment() {
-        assert_eq!(skip(b"/* foo */hello"), Result::Done(&b"hello"[..], vec![&b" foo "[..]]));
-    }
-
-    #[test]
-    fn case_skip_whitespace() {
-        assert_eq!(skip(b"  \nhello"), Result::Done(&b"hello"[..], vec![&b"  \n"[..]]));
-    }
-
-    #[test]
-    fn case_skip_comment_whitespace() {
-        assert_eq!(skip(b"/* foo */  \nhello"), Result::Done(&b"hello"[..], vec![&b" foo "[..], &b"  \n"[..]]));
-    }
-}
+pub use nom::Err as Error;
+pub use nom::ErrorKind;
+pub use nom::IResult as Result;
+pub use nom::Needed;

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -62,12 +62,14 @@ extern crate lazy_static;
 extern crate nom;
 extern crate regex;
 
+pub mod internal;
 #[macro_use]
 pub mod macros;
-
 pub mod ast;
 pub mod rules;
 pub mod tokens;
+
+pub use self::internal::*;
 
 /// Complete parsing of a datum starting by the sentence symbol of the grammar.
 ///

--- a/source/rules/comments.rs
+++ b/source/rules/comments.rs
@@ -62,18 +62,21 @@ named!(
 
 #[cfg(test)]
 mod tests {
-    use nom::IResult::{Done, Error};
-    use nom::{Err, ErrorKind};
     use super::{
         comment,
         comment_delimited,
         comment_single_line
     };
+    use super::super::super::internal::{
+        Error,
+        ErrorKind,
+        Result
+    };
 
     #[test]
     fn case_comment_single_line_double_slash_empty() {
         let input  = b"//";
-        let output = Done(&b""[..], &b""[..]);
+        let output = Result::Done(&b""[..], &b""[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -82,7 +85,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_double_slash_with_feed() {
         let input  = b"// foobar\nbazqux";
-        let output = Done(&b"bazqux"[..], &b" foobar\n"[..]);
+        let output = Result::Done(&b"bazqux"[..], &b" foobar\n"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -91,7 +94,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_double_slash_with_carriage_return() {
         let input  = b"// foobar\rbazqux";
-        let output = Done(&b"bazqux"[..], &b" foobar\r"[..]);
+        let output = Result::Done(&b"bazqux"[..], &b" foobar\r"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -100,7 +103,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_double_slash_with_carriage_return_feed() {
         let input  = b"// foobar\r\nbazqux";
-        let output = Done(&b"bazqux"[..], &b" foobar\r\n"[..]);
+        let output = Result::Done(&b"bazqux"[..], &b" foobar\r\n"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -109,7 +112,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_double_slash_without_ending() {
         let input  = b"// foobar";
-        let output = Done(&b""[..], &b" foobar"[..]);
+        let output = Result::Done(&b""[..], &b" foobar"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -118,7 +121,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_double_slash_embedded() {
         let input  = b"//foo//bar";
-        let output = Done(&b""[..], &b"foo//bar"[..]);
+        let output = Result::Done(&b""[..], &b"foo//bar"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -127,7 +130,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_hash_empty() {
         let input  = b"#";
-        let output = Done(&b""[..], &b""[..]);
+        let output = Result::Done(&b""[..], &b""[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -136,7 +139,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_hash_with_line_feed() {
         let input  = b"# foobar\nbazqux";
-        let output = Done(&b"bazqux"[..], &b" foobar\n"[..]);
+        let output = Result::Done(&b"bazqux"[..], &b" foobar\n"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -145,7 +148,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_hash_with_carriage_return() {
         let input  = b"# foobar\rbazqux";
-        let output = Done(&b"bazqux"[..], &b" foobar\r"[..]);
+        let output = Result::Done(&b"bazqux"[..], &b" foobar\r"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -154,7 +157,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_hash_with_carriage_return_line_feed() {
         let input  = b"# foobar\r\nbazqux";
-        let output = Done(&b"bazqux"[..], &b" foobar\r\n"[..]);
+        let output = Result::Done(&b"bazqux"[..], &b" foobar\r\n"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -163,7 +166,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_hash_without_line_ending() {
         let input  = b"# foobar";
-        let output = Done(&b""[..], &b" foobar"[..]);
+        let output = Result::Done(&b""[..], &b" foobar"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -172,7 +175,7 @@ mod tests {
     #[test]
     fn case_comment_single_line_hash_embedded() {
         let input  = b"#foo#bar";
-        let output = Done(&b""[..], &b"foo#bar"[..]);
+        let output = Result::Done(&b""[..], &b"foo#bar"[..]);
 
         assert_eq!(comment_single_line(input), output);
         assert_eq!(comment(input), output);
@@ -181,7 +184,7 @@ mod tests {
     #[test]
     fn case_comment_delimited_empty() {
         let input  = b"/**/xyz";
-        let output = Done(&b"xyz"[..], &b""[..]);
+        let output = Result::Done(&b"xyz"[..], &b""[..]);
 
         assert_eq!(comment_delimited(input), output);
         assert_eq!(comment(input), output);
@@ -190,7 +193,7 @@ mod tests {
     #[test]
     fn case_comment_delimited() {
         let input  = b"/* foo bar\nbaz\r\nqux // hello,\n /*world!*/xyz */";
-        let output = Done(&b"xyz */"[..], &b" foo bar\nbaz\r\nqux // hello,\n /*world!"[..]);
+        let output = Result::Done(&b"xyz */"[..], &b" foo bar\nbaz\r\nqux // hello,\n /*world!"[..]);
 
         assert_eq!(comment_delimited(input), output);
         assert_eq!(comment(input), output);
@@ -200,7 +203,7 @@ mod tests {
     fn case_invalid_comment_delimited_not_closed() {
         let input = b"/*foobar";
 
-        assert_eq!(comment_delimited(input), Error(Err::Position(ErrorKind::TakeUntilAndConsume, &b"foobar"[..])));
-        assert_eq!(comment(input), Error(Err::Position(ErrorKind::Alt, &input[..])));
+        assert_eq!(comment_delimited(input), Result::Error(Error::Position(ErrorKind::TakeUntilAndConsume, &b"foobar"[..])));
+        assert_eq!(comment(input), Result::Error(Error::Position(ErrorKind::Alt, &input[..])));
     }
 }

--- a/source/rules/expressions.rs
+++ b/source/rules/expressions.rs
@@ -48,16 +48,24 @@ named!(
 
 #[cfg(test)]
 mod tests {
-    use nom::IResult::Done;
     use super::expr;
     use super::super::super::ast;
+    use super::super::super::internal::Result;
 
     #[test]
     fn case_expr() {
         assert_eq!(
             expr(b"1+2"),
-            Done(
-                &b""[..], ast::Addition { a: ast::Term { t: ast::Literal::Integer(1) }, b: ast::Term { t: ast::Literal::Integer(2) } }
+            Result::Done(
+                &b""[..],
+                ast::Addition {
+                    a: ast::Term {
+                        t: ast::Literal::Integer(1)
+                    },
+                    b: ast::Term {
+                        t: ast::Literal::Integer(2)
+                    }
+                }
             )
         );
     }

--- a/source/rules/mod.rs
+++ b/source/rules/mod.rs
@@ -41,11 +41,11 @@ pub mod tokens;
 pub mod whitespaces;
 
 use super::ast;
-use nom::IResult::Done;
+use super::internal::*;
 
 pub fn root(input: &[u8]) -> ast::Addition {
     match expressions::expr(input) {
-        Done(_, ast) => ast,
+        Result::Done(_, ast) => ast,
         _ => panic!("Youhouuu")
     }
 }
@@ -53,16 +53,24 @@ pub fn root(input: &[u8]) -> ast::Addition {
 
 #[cfg(test)]
 mod tests {
-    use nom::IResult::Done;
     use super::expressions::expr;
     use super::super::ast;
+    use super::super::internal::Result;
 
     #[test]
     fn case_expr() {
         assert_eq!(
             expr(b"1+2"),
-            Done(
-                &b""[..], ast::Addition { a: ast::Term { t: ast::Literal::Integer(1) }, b: ast::Term { t: ast::Literal::Integer(2) } }
+            Result::Done(
+                &b""[..],
+                ast::Addition {
+                    a: ast::Term {
+                        t: ast::Literal::Integer(1)
+                    },
+                    b: ast::Term {
+                        t: ast::Literal::Integer(2)
+                    }
+                }
             )
         );
     }

--- a/source/rules/whitespaces.rs
+++ b/source/rules/whitespaces.rs
@@ -43,57 +43,60 @@ named!(
 
 #[cfg(test)]
 mod tests {
-    use nom::IResult::{Done, Error};
-    use nom::{Err, ErrorKind};
+    use super::super::super::internal::{
+        Error,
+        ErrorKind,
+        Result
+    };
     use super::whitespace;
 
     #[test]
     fn case_whitespace_space() {
-        assert_eq!(whitespace(b"   "), Done(&b""[..], &b"   "[..]));
+        assert_eq!(whitespace(b"   "), Result::Done(&b""[..], &b"   "[..]));
     }
 
     #[test]
     fn case_whitespace_horizontal_tabulation() {
-        assert_eq!(whitespace(b"\t\t\t"), Done(&b""[..], &b"\t\t\t"[..]));
+        assert_eq!(whitespace(b"\t\t\t"), Result::Done(&b""[..], &b"\t\t\t"[..]));
     }
 
     #[test]
     fn case_whitespace_carriage_return_line_feed() {
-        assert_eq!(whitespace(b"\r\n\r\n\r\n"), Done(&b""[..], &b"\r\n\r\n\r\n"[..]));
+        assert_eq!(whitespace(b"\r\n\r\n\r\n"), Result::Done(&b""[..], &b"\r\n\r\n\r\n"[..]));
     }
 
     #[test]
     fn case_whitespace_carriage_return() {
-        assert_eq!(whitespace(b"\r\r\r"), Done(&b""[..], &b"\r\r\r"[..]));
+        assert_eq!(whitespace(b"\r\r\r"), Result::Done(&b""[..], &b"\r\r\r"[..]));
     }
 
     #[test]
     fn case_whitespace_line_feed() {
-        assert_eq!(whitespace(b"\n\n\n"), Done(&b""[..], &b"\n\n\n"[..]));
+        assert_eq!(whitespace(b"\n\n\n"), Result::Done(&b""[..], &b"\n\n\n"[..]));
     }
 
     #[test]
     fn case_whitespace_mixed() {
-        assert_eq!(whitespace(b"\n \n \r\t  \t\r\n\t \t\t"), Done(&b""[..], &b"\n \n \r\t  \t\r\n\t \t\t"[..]));
+        assert_eq!(whitespace(b"\n \n \r\t  \t\r\n\t \t\t"), Result::Done(&b""[..], &b"\n \n \r\t  \t\r\n\t \t\t"[..]));
     }
 
     #[test]
     fn case_whitespace_with_a_tail() {
-        assert_eq!(whitespace(b"\n \n \r\t  \t\r\n\t \t\tabc "), Done(&b"abc "[..], &b"\n \n \r\t  \t\r\n\t \t\t"[..]));
+        assert_eq!(whitespace(b"\n \n \r\t  \t\r\n\t \t\tabc "), Result::Done(&b"abc "[..], &b"\n \n \r\t  \t\r\n\t \t\t"[..]));
     }
 
     #[test]
     fn case_whitespace_too_short() {
-        assert_eq!(whitespace(b""), Done(&b""[..], &b""[..]));
+        assert_eq!(whitespace(b""), Result::Done(&b""[..], &b""[..]));
     }
 
     #[test]
     fn case_invalid_whitespace_not_a_valid_whitespace() {
-        assert_eq!(whitespace(b"\xa0 "), Error(Err::Position(ErrorKind::IsA, &b"\xa0 "[..])));
+        assert_eq!(whitespace(b"\xa0 "), Result::Error(Error::Position(ErrorKind::IsA, &b"\xa0 "[..])));
     }
 
     #[test]
     fn case_invalid_whitespace_not_a_valid_character() {
-        assert_eq!(whitespace(b"abc\n \t"), Error(Err::Position(ErrorKind::IsA, &b"abc\n \t"[..])));
+        assert_eq!(whitespace(b"abc\n \t"), Result::Error(Error::Position(ErrorKind::IsA, &b"abc\n \t"[..])));
     }
 }

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -655,9 +655,12 @@ named!(
 
 #[cfg(test)]
 mod tests {
-    use nom::IResult::{Done, Error};
-    use nom::{Err, ErrorKind};
     use super::keywords;
+    use super::super::internal::{
+        Error,
+        ErrorKind,
+        Result
+    };
 
     macro_rules! test_keyword {
         ($test_case_name:ident: ($string:expr, $expect:expr)) => (
@@ -666,7 +669,7 @@ mod tests {
                 use std::ascii::AsciiExt;
                 use std::str;
 
-                let output     = Done(&b""[..], $expect);
+                let output     = Result::Done(&b""[..], $expect);
                 let uppercased = str::from_utf8($string).unwrap().to_ascii_uppercase();
 
                 assert_eq!(keywords($string), output);
@@ -747,6 +750,6 @@ mod tests {
 
     #[test]
     fn case_invalid_keyword() {
-        assert_eq!(keywords(b"hello"), Error(Err::Position(ErrorKind::Alt, &b"hello"[..])));
+        assert_eq!(keywords(b"hello"), Result::Error(Error::Position(ErrorKind::Alt, &b"hello"[..])));
     }
 }


### PR DESCRIPTION
The new `internal` module introduces type aliases (by re-exporting the entities) from nom for a better flexibility:
- `nom::Err` becomes `Error`,
- `nom::ErrorKind` becomes `ErrorKind`,
- `nom::IResult` becomes `Result`,
- `nom::Needed` becomes `Needed`.

It also simplifies the documentation and the examples: Less dependencies are required to understand them.
