### PR TITLE
Literal: Add support for zero

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: rust
 rust:
-  - 1.7.0
-  - 1.8.0
   - 1.9.0
   - stable
   - beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,11 @@ codegen-units    = 1
 
 [dependencies]
 lazy_static = "~0.1"
-regex = "~0.1"
+regex       = "~0.1"
 
 [dependencies.nom]
-version = "^1.2.3"
+version  = "^1.2.3"
 features = ["regexp", "regexp_macros"]
+
+[dev-dependencies]
+quickcheck = "~0.3"

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -61,6 +61,9 @@ extern crate lazy_static;
 #[macro_use]
 extern crate nom;
 extern crate regex;
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
 
 #[macro_use]
 pub mod macros;

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -538,6 +538,21 @@ mod tests {
         assert_eq!(literal(input), output);
     }
 
+    quickcheck! {
+        fn case_decimal_random(input: u32) -> bool {
+            let string = input.to_string();
+            let bytes  = string.as_bytes();
+
+            match decimal(bytes) {
+                Done(_, Literal::Integer(output)) =>
+                    input == output as u32,
+
+                _ =>
+                    false
+            }
+        }
+    }
+
     #[test]
     fn case_decimal_plus() {
         let input  = b"42+";


### PR DESCRIPTION
Initially, this PR was about introducing [quickcheck](https://github.com/BurntSushi/quickcheck) inside `tagua/parser`.

Quickly, a bug has been found. `0` (zero) was not a possible literal. So this PR also contains a patch to support zero. The 0 value comes from the octal representation.
