### PR TITLE
Literal: Optimize `alt!(…)` with `is_a!(…)`.

### DIFF
--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -97,7 +97,7 @@ named!(
         preceded!(
             tag!("0"),
             preceded!(
-                alt!(tag!("b") | tag!("B")),
+                is_a!("bB"),
                 is_a!("01")
             )
         ),
@@ -176,7 +176,7 @@ named!(
         preceded!(
             tag!("0"),
             preceded!(
-                alt!(tag!("x") | tag!("X")),
+                is_a!("xX"),
                 hex_digit
             )
         ),


### PR DESCRIPTION
The pattern `alt!(tag!(X_1) | tag!(X_2) | … | tag!(X_n))` can be safely replaced by `is_a!(X_1X_2…X_n)` if `X_i` are strings of length 1. `is_a!` is almost twice faster than `alt!`.

With a `[bench]`, we observe we save 4ns per literal.
