### PR TITLE
Quality: Restrict some tasks to Linux and stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,8 @@ script:
       travis-cargo test &&
       travis-cargo --only stable doc
 after_success:
-  - travis-cargo --only stable doc-upload
-  - travis-cargo coveralls --no-sudo
+  - |
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+          travis-cargo --only stable doc-upload;
+          travis-cargo --only stable coveralls --no-sudo;
+      fi


### PR DESCRIPTION
Uploading the documentation and uploading coverage reports must be on stable Rust version only, and on Linux only.
