### PR TITLE
Literal: Support spaces before nowdoc identifier

### DIFF
--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -1082,6 +1082,16 @@ mod tests {
     }
 
     #[test]
+    fn case_invalid_string_nowdoc_opening_character() {
+        let input  = b"<<FOO'\nhello \n  world \nFOO\n";
+        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+
+        assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
+        assert_eq!(string(input), output);
+        assert_eq!(literal(input), output);
+    }
+
+    #[test]
     fn case_invalid_string_nowdoc_opening_character_missing_first_quote() {
         let input  = b"<<<FOO'\nhello \n  world \nFOO\n";
         let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
@@ -1172,6 +1182,16 @@ mod tests {
     }
 
     #[test]
+    fn case_invalid_string_binary_nowdoc_opening_character() {
+        let input  = b"b<<FOO'\nhello \n  world \nFOO\n";
+        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+
+        assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
+        assert_eq!(string(input), output);
+        assert_eq!(literal(input), output);
+    }
+
+    #[test]
     fn case_invalid_string_binary_nowdoc_opening_character_missing_first_quote() {
         let input  = b"b<<<FOO'\nhello \n  world \nFOO\n";
         let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
@@ -1197,6 +1217,16 @@ mod tests {
         let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32))));
+        assert_eq!(string(input), output);
+        assert_eq!(literal(input), output);
+    }
+
+    #[test]
+    fn case_invalid_string_binary_uppercase_nowdoc_opening_character() {
+        let input  = b"B<<FOO'\nhello \n  world \nFOO\n";
+        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+
+        assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
         assert_eq!(literal(input), output);
     }


### PR DESCRIPTION
Fix #33.
