### PR TITLE
Expression: `array` is a keyword, not a `tag`

### DIFF
--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -107,7 +107,7 @@ named!(
         )
       | preceded!(
             preceded!(
-                tag!(tokens::ARRAY),
+                keyword!(tokens::ARRAY),
                 first!(tag!(tokens::LEFT_PARENTHESIS))
             ),
             alt!(


### PR DESCRIPTION
This way, `array(…)` is equivalent to `ARRAY(…)`, and all intermediate forms.