### PR TITLE
Shrink memory of vectors

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -485,7 +485,7 @@ pub enum Expression<'a> {
     /// ```
     /// # extern crate tagua_parser;
     /// use tagua_parser::Result;
-    /// use tagua_parser::ast::{Expression, Literal, Variable};
+    /// use tagua_parser::ast::{Expression, Variable};
     /// use tagua_parser::rules::expressions::expression;
     ///
     /// # fn main () {


### PR DESCRIPTION
Introduce a new macro: `fold_into_vector_many0!`.
It is basically similar to:
```rust
fold_many0!(
    submacro!(…),
    accumulator,
    fold_into_vector
)
```
but it automatically shrinks the resulting vector.

Another interesting step would be to analyse a lot of code to determine the average initial capacity for the vectors.