### PR TITLE
Migrate to the new nom 2.0

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -61,7 +61,7 @@ pub enum Literal {
     /// use tagua_parser::rules::literals::literal;
     ///
     /// # fn main () {
-    /// assert_eq!(literal(b"true"),  Result::Done(&b""[..], Literal::Boolean(true)));
+    /// assert_eq!(literal(b"true"), Result::Done(&b""[..], Literal::Boolean(true)));
     /// assert_eq!(literal(b"false"), Result::Done(&b""[..], Literal::Boolean(false)));
     /// # }
     /// ```

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -271,22 +271,20 @@ pub enum Expression<'a> {
     ///     expression(b"['foo', 42 => 'bar', 'baz' => $qux]"),
     ///     Result::Done(
     ///         &b""[..],
-    ///         Expression::Array(
-    ///             vec![
-    ///                 (
-    ///                     None,
-    ///                     Expression::Literal(Literal::String(b"foo".to_vec()))
-    ///                 ),
-    ///                 (
-    ///                     Some(Expression::Literal(Literal::Integer(42i64))),
-    ///                     Expression::Literal(Literal::String(b"bar".to_vec()))
-    ///                 ),
-    ///                 (
-    ///                     Some(Expression::Literal(Literal::String(b"baz".to_vec()))),
-    ///                     Expression::Variable(Variable(&b"qux"[..]))
-    ///                 )
-    ///             ]
-    ///         )
+    ///         Expression::Array(vec![
+    ///             (
+    ///                 None,
+    ///                 Expression::Literal(Literal::String(b"foo".to_vec()))
+    ///             ),
+    ///             (
+    ///                 Some(Expression::Literal(Literal::Integer(42i64))),
+    ///                 Expression::Literal(Literal::String(b"bar".to_vec()))
+    ///             ),
+    ///             (
+    ///                 Some(Expression::Literal(Literal::String(b"baz".to_vec()))),
+    ///                 Expression::Variable(Variable(&b"qux"[..]))
+    ///             )
+    ///         ])
     ///     )
     /// );
     /// # }
@@ -311,13 +309,11 @@ pub enum Expression<'a> {
     ///     expression(b"echo 'foobar', $bazqux, 42"),
     ///     Result::Done(
     ///         &b""[..],
-    ///         Expression::Echo(
-    ///             vec![
-    ///                 Expression::Literal(Literal::String(b"foobar".to_vec())),
-    ///                 Expression::Variable(Variable(&b"bazqux"[..])),
-    ///                 Expression::Literal(Literal::Integer(42i64))
-    ///             ]
-    ///         )
+    ///         Expression::Echo(vec![
+    ///             Expression::Literal(Literal::String(b"foobar".to_vec())),
+    ///             Expression::Variable(Variable(&b"bazqux"[..])),
+    ///             Expression::Literal(Literal::Integer(42i64))
+    ///         ])
     ///     )
     /// );
     /// # }
@@ -431,12 +427,10 @@ pub enum Expression<'a> {
     ///     expression(b"isset($foo, $bar)"),
     ///     Result::Done(
     ///         &b""[..],
-    ///         Expression::Isset(
-    ///             vec![
-    ///                 Expression::Variable(Variable(&b"foo"[..])),
-    ///                 Expression::Variable(Variable(&b"bar"[..]))
-    ///             ]
-    ///         )
+    ///         Expression::Isset(vec![
+    ///             Expression::Variable(Variable(&b"foo"[..])),
+    ///             Expression::Variable(Variable(&b"bar"[..]))
+    ///         ])
     ///     )
     /// );
     /// # }
@@ -597,16 +591,14 @@ pub enum Expression<'a> {
     ///     expression(b"[7 => &$foo]"),
     ///     Result::Done(
     ///         &b""[..],
-    ///         Expression::Array(
-    ///             vec![
-    ///                 (
-    ///                     Some(Expression::Literal(Literal::Integer(7i64))),
-    ///                     Expression::Reference(
-    ///                         Box::new(Expression::Variable(Variable(&b"foo"[..])))
-    ///                     )
+    ///         Expression::Array(vec![
+    ///             (
+    ///                 Some(Expression::Literal(Literal::Integer(7i64))),
+    ///                 Expression::Reference(
+    ///                     Box::new(Expression::Variable(Variable(&b"foo"[..])))
     ///                 )
-    ///             ]
-    ///         )
+    ///             )
+    ///         ])
     ///     )
     /// );
     /// # }
@@ -629,12 +621,10 @@ pub enum Expression<'a> {
     ///     expression(b"unset($foo, $bar)"),
     ///     Result::Done(
     ///         &b""[..],
-    ///         Expression::Unset(
-    ///             vec![
-    ///                 Expression::Variable(Variable(&b"foo"[..])),
-    ///                 Expression::Variable(Variable(&b"bar"[..]))
-    ///             ]
-    ///         )
+    ///         Expression::Unset(vec![
+    ///             Expression::Variable(Variable(&b"foo"[..])),
+    ///             Expression::Variable(Variable(&b"bar"[..]))
+    ///         ])
     ///     )
     /// );
     /// # }

--- a/source/rules/comments.rs
+++ b/source/rules/comments.rs
@@ -35,7 +35,24 @@
 //! the [Grammar chapter, Comments
 //! section](https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#comments).
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all kind of comments.
+
+        A comment can be a single line (`//` or `#`) or a delimited block (`/* … */`).
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::rules::comments::comment;
+
+        # fn main () {
+        assert_eq!(comment(b\"/* foo */ bar\"), Result::Done(&b\" bar\"[..], &b\" foo \"[..]));
+        # }
+        ```
+    "],
     pub comment,
     alt!(
         comment_single_line

--- a/source/rules/expressions/mod.rs
+++ b/source/rules/expressions/mod.rs
@@ -39,7 +39,31 @@ pub mod primaries;
 
 use super::super::ast::Expression;
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all kind of expressions.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal};
+        use tagua_parser::rules::expressions::expression;
+
+        # fn main () {
+        assert_eq!(
+            expression(b\"echo 'Hello, World!'\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Echo(vec![
+                    Expression::Literal(Literal::String(b\"Hello, World!\".to_vec()))
+                ])
+            )
+        );
+        # }
+        ```
+    "],
     pub expression<Expression>,
     call!(primaries::primary)
 );

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -481,7 +481,31 @@ fn intrinsic_list_mapper<'a>(expression: Expression<'a>) -> StdResult<Expression
     }
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an unset.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Variable};
+        use tagua_parser::rules::expressions::primaries::intrinsic_unset;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic_unset(b\"unset($foo, $bar)\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Unset(vec![
+                    Expression::Variable(Variable(&b\"foo\"[..])),
+                    Expression::Variable(Variable(&b\"bar\"[..]))
+                ])
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic_unset<Expression>,
     do_parse!(
         accumulator: map_res!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -1788,11 +1788,9 @@ mod tests {
         let input  = b"isset($foo)";
         let output = Result::Done(
             &b""[..],
-            Expression::Isset(
-                vec![
-                    Expression::Variable(Variable(&b"foo"[..]))
-                ]
-            )
+            Expression::Isset(vec![
+                Expression::Variable(Variable(&b"foo"[..]))
+            ])
         );
 
         assert_eq!(intrinsic_isset(input), output);
@@ -1806,13 +1804,11 @@ mod tests {
         let input  = b"isset($foo, $bar, $baz)";
         let output = Result::Done(
             &b""[..],
-            Expression::Isset(
-                vec![
-                    Expression::Variable(Variable(&b"foo"[..])),
-                    Expression::Variable(Variable(&b"bar"[..])),
-                    Expression::Variable(Variable(&b"baz"[..]))
-                ]
-            )
+            Expression::Isset(vec![
+                Expression::Variable(Variable(&b"foo"[..])),
+                Expression::Variable(Variable(&b"bar"[..])),
+                Expression::Variable(Variable(&b"baz"[..]))
+            ])
         );
 
         assert_eq!(intrinsic_isset(input), output);

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -763,7 +763,32 @@ fn into_isset<'a>(expressions: Vec<Expression<'a>>) -> Expression<'a> {
     Expression::Isset(expressions)
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a print.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal};
+        use tagua_parser::rules::expressions::primaries::intrinsic_print;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic_print(b\"print('Hello, World!')\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Print(
+                    Box::new(
+                        Expression::Literal(Literal::String(b\"Hello, World!\".to_vec()))
+                    )
+                )
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic_print<Expression>,
     map_res!(
         preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -707,7 +707,31 @@ fn exit_mapper<'a>(expression: Option<Expression<'a>>) -> StdResult<Expression<'
     }
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an exit.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Variable};
+        use tagua_parser::rules::expressions::primaries::intrinsic_isset;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic_isset(b\"isset($foo, $bar)\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Isset(vec![
+                    Expression::Variable(Variable(&b\"foo\"[..])),
+                    Expression::Variable(Variable(&b\"bar\"[..]))
+                ])
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic_isset<Expression>,
     do_parse!(
         accumulator: map_res!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -134,32 +134,32 @@ named!(
 
 named!(
     array_pairs<Expression>,
-    chain!(
+    do_parse!(
         accumulator: map_res!(
             first!(array_pair),
             into_vector_mapper
-        ) ~
+        ) >>
         result: fold_into_vector_many0!(
             preceded!(
                 first!(tag!(tokens::COMMA)),
                 first!(array_pair)
             ),
             accumulator
-        ) ~
-        opt!(first!(tag!(tokens::COMMA))),
-        || { into_array(result) }
+        ) >>
+        opt!(first!(tag!(tokens::COMMA))) >>
+        (into_array(result))
     )
 );
 
 named!(
     array_pair<(Option<Expression>, Expression)>,
-    chain!(
+    do_parse!(
         key: opt!(
             terminated!(
                 expression,
                 first!(tag!(tokens::MAP))
             )
-        ) ~
+        ) >>
         value: alt!(
             map_res!(
                 preceded!(
@@ -169,8 +169,8 @@ named!(
                 value_by_reference_array_mapper
             )
           | first!(expression)
-        ),
-        || { (key, value) }
+        ) >>
+        ((key, value))
     )
 );
 
@@ -219,22 +219,22 @@ named!(
 
 named!(
     intrinsic_echo<Expression>,
-    chain!(
+    do_parse!(
         accumulator: map_res!(
             preceded!(
                 keyword!(tokens::ECHO),
                 first!(expression)
             ),
             into_vector_mapper
-        ) ~
+        ) >>
         result: fold_into_vector_many0!(
             preceded!(
                 first!(tag!(tokens::COMMA)),
                 first!(expression)
             ),
             accumulator
-        ),
-        || { into_echo(result) }
+        ) >>
+        (into_echo(result))
     )
 );
 
@@ -270,58 +270,58 @@ named!(
 
 named!(
     intrinsic_keyed_list<Expression>,
-    chain!(
+    do_parse!(
         accumulator: map_res!(
             first!(intrinsic_keyed_list_item),
             into_vector_mapper
-        ) ~
+        ) >>
         result: fold_into_vector_many0!(
             preceded!(
                 first!(tag!(tokens::COMMA)),
                 first!(intrinsic_keyed_list_item)
             ),
             accumulator
-        ) ~
-        opt!(first!(tag!(tokens::COMMA))),
-        || { into_list(result) }
+        ) >>
+        opt!(first!(tag!(tokens::COMMA))) >>
+        (into_list(result))
     )
 );
 
 named!(
     intrinsic_unkeyed_list<Expression>,
-    chain!(
+    do_parse!(
         accumulator: map_res!(
             opt!(first!(intrinsic_unkeyed_list_item)),
             into_vector_mapper
-        ) ~
+        ) >>
         result: fold_into_vector_many0!(
             preceded!(
                 first!(tag!(tokens::COMMA)),
                 opt!(first!(intrinsic_unkeyed_list_item))
             ),
             accumulator
-        ),
-        || { into_list(result) }
+        ) >>
+        (into_list(result))
     )
 );
 
 named!(
     intrinsic_keyed_list_item< Option<(Option<Expression>, Expression)> >,
-    chain!(
+    do_parse!(
         key: terminated!(
             expression,
             first!(tag!(tokens::MAP))
-        ) ~
-        value: first!(expression),
-        || { Some((Some(key), value)) }
+        ) >>
+        value: first!(expression) >>
+        (Some((Some(key), value)))
     )
 );
 
 named!(
     intrinsic_unkeyed_list_item<(Option<Expression>, Expression)>,
-    chain!(
-        value: expression,
-        || { (None, value) }
+    do_parse!(
+        value: expression >>
+        ((None, value))
     )
 );
 
@@ -349,7 +349,7 @@ fn intrinsic_list_mapper<'a>(expression: Expression<'a>) -> StdResult<Expression
 
 named!(
     intrinsic_unset<Expression>,
-    chain!(
+    do_parse!(
         accumulator: map_res!(
             preceded!(
                 keyword!(tokens::UNSET),
@@ -359,7 +359,7 @@ named!(
                 )
             ),
             into_vector_mapper
-        ) ~
+        ) >>
         result: terminated!(
             fold_into_vector_many0!(
                 preceded!(
@@ -369,8 +369,8 @@ named!(
                 accumulator
             ),
             first!(tag!(tokens::RIGHT_PARENTHESIS))
-        ),
-        || { into_unset(result) }
+        ) >>
+        (into_unset(result))
     )
 );
 
@@ -468,7 +468,7 @@ fn exit_mapper<'a>(expression: Option<Expression<'a>>) -> StdResult<Expression<'
 
 named!(
     intrinsic_isset<Expression>,
-    chain!(
+    do_parse!(
         accumulator: map_res!(
             preceded!(
                 keyword!(tokens::ISSET),
@@ -478,7 +478,7 @@ named!(
                 )
             ),
             into_vector_mapper
-        ) ~
+        ) >>
         result: terminated!(
             fold_into_vector_many0!(
                 preceded!(
@@ -488,8 +488,8 @@ named!(
                 accumulator
             ),
             first!(tag!(tokens::RIGHT_PARENTHESIS))
-        ),
-        || { into_isset(result) }
+        ) >>
+        (into_isset(result))
     )
 );
 

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -66,7 +66,31 @@ pub enum IntrinsicError {
     ListIsEmpty
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all kind of primary expressions.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal};
+        use tagua_parser::rules::expressions::primaries::primary;
+
+        # fn main () {
+        assert_eq!(
+            primary(b\"echo 'Hello, World!'\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Echo(vec![
+                    Expression::Literal(Literal::String(b\"Hello, World!\".to_vec()))
+                ])
+            )
+        );
+        # }
+        ```
+    "],
     pub primary<Expression>,
     alt!(
         variable       => { variable_mapper }

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -708,7 +708,7 @@ fn exit_mapper<'a>(expression: Option<Expression<'a>>) -> StdResult<Expression<'
 }
 
 named!(
-    intrinsic_isset<Expression>,
+    pub intrinsic_isset<Expression>,
     do_parse!(
         accumulator: map_res!(
             preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -537,7 +537,34 @@ fn into_unset<'a>(expressions: Vec<Expression<'a>>) -> Expression<'a> {
     Expression::Unset(expressions)
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an empty.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal};
+        use tagua_parser::rules::expressions::primaries::intrinsic_empty;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic_empty(b\"empty('foo')\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Empty(
+                    Box::new(
+                        Expression::Literal(
+                            Literal::String(b\"foo\".to_vec())
+                        )
+                    )
+                )
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic_empty<Expression>,
     map_res!(
         preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -298,7 +298,7 @@ named!(
 );
 
 named!(
-    intrinsic_echo<Expression>,
+    pub intrinsic_echo<Expression>,
     do_parse!(
         accumulator: map_res!(
             preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -1390,11 +1390,9 @@ mod tests {
         let input  = b"unset($foo)";
         let output = Result::Done(
             &b""[..],
-            Expression::Unset(
-                vec![
-                    Expression::Variable(Variable(&b"foo"[..]))
-                ]
-            )
+            Expression::Unset(vec![
+                Expression::Variable(Variable(&b"foo"[..]))
+            ])
         );
 
         assert_eq!(intrinsic_unset(input), output);
@@ -1408,13 +1406,11 @@ mod tests {
         let input  = b"unset($foo, $bar, $baz)";
         let output = Result::Done(
             &b""[..],
-            Expression::Unset(
-                vec![
-                    Expression::Variable(Variable(&b"foo"[..])),
-                    Expression::Variable(Variable(&b"bar"[..])),
-                    Expression::Variable(Variable(&b"baz"[..]))
-                ]
-            )
+            Expression::Unset(vec![
+                Expression::Variable(Variable(&b"foo"[..])),
+                Expression::Variable(Variable(&b"bar"[..])),
+                Expression::Variable(Variable(&b"baz"[..]))
+            ])
         );
 
         assert_eq!(intrinsic_unset(input), output);

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -246,7 +246,30 @@ fn into_array<'a>(expressions: Vec<(Option<Expression<'a>>, Expression<'a>)>) ->
     Expression::Array(expressions)
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all kind of intrinsics.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal};
+        use tagua_parser::rules::expressions::primaries::intrinsic;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic(b\"echo 'Hello, World!'\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Echo(vec![
+                    Expression::Literal(Literal::String(b\"Hello, World!\".to_vec()))
+                ])
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic<Expression>,
     alt!(
         intrinsic_construct

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -58,8 +58,10 @@ use super::super::super::tokens;
 pub enum IntrinsicError {
     /// The exit code is reserved (only 255 is reserved to PHP).
     ReservedExitCode,
+
     /// The exit code is out of range if greater than 255.
     OutOfRangeExitCode,
+
     /// The list constructor must contain at least one item.
     ListIsEmpty
 }

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -482,7 +482,7 @@ fn intrinsic_list_mapper<'a>(expression: Expression<'a>) -> StdResult<Expression
 }
 
 named!(
-    intrinsic_unset<Expression>,
+    pub intrinsic_unset<Expression>,
     do_parse!(
         accumulator: map_res!(
             preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -587,7 +587,7 @@ fn empty_mapper<'a>(expression: Expression<'a>) -> StdResult<Expression<'a>, ()>
 }
 
 named!(
-    intrinsic_eval<Expression>,
+    pub intrinsic_eval<Expression>,
     map_res!(
         preceded!(
             keyword!(tokens::EVAL),

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -586,7 +586,34 @@ fn empty_mapper<'a>(expression: Expression<'a>) -> StdResult<Expression<'a>, ()>
     Ok(Expression::Empty(Box::new(expression)))
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an lazy evaluation.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal};
+        use tagua_parser::rules::expressions::primaries::intrinsic_eval;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic_eval(b\"eval('1 + 2')\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Eval(
+                    Box::new(
+                        Expression::Literal(
+                            Literal::String(b\"1 + 2\".to_vec())
+                        )
+                    )
+                )
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic_eval<Expression>,
     map_res!(
         preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -764,7 +764,7 @@ fn into_isset<'a>(expressions: Vec<Expression<'a>>) -> Expression<'a> {
 }
 
 named!(
-    intrinsic_print<Expression>,
+    pub intrinsic_print<Expression>,
     map_res!(
         preceded!(
             keyword!(tokens::PRINT),

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -297,7 +297,31 @@ named!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an echo.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal};
+        use tagua_parser::rules::expressions::primaries::intrinsic_echo;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic_echo(b\"echo 'Hello,', ' World!'\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Echo(vec![
+                    Expression::Literal(Literal::String(b\"Hello,\".to_vec())),
+                    Expression::Literal(Literal::String(b\" World!\".to_vec()))
+                ])
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic_echo<Expression>,
     do_parse!(
         accumulator: map_res!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -352,7 +352,37 @@ fn into_echo<'a>(expressions: Vec<Expression<'a>>) -> Expression<'a> {
     Expression::Echo(expressions)
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a list.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal, Variable};
+        use tagua_parser::rules::expressions::primaries::intrinsic_list;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic_list(b\"list('foo' => $foo, 'bar' => $bar)\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::List(vec![
+                    Some((
+                        Some(Expression::Literal(Literal::String(b\"foo\".to_vec()))),
+                        Expression::Variable(Variable(&b\"foo\"[..]))
+                    )),
+                    Some((
+                        Some(Expression::Literal(Literal::String(b\"bar\".to_vec()))),
+                        Expression::Variable(Variable(&b\"bar\"[..]))
+                    ))
+                ])
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic_list<Expression>,
     map_res!(
         preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -636,7 +636,7 @@ fn eval_mapper<'a>(expression: Expression<'a>) -> StdResult<Expression<'a>, ()> 
 }
 
 named!(
-    intrinsic_exit<Expression>,
+    pub intrinsic_exit<Expression>,
     map_res!(
         preceded!(
             alt!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -635,7 +635,36 @@ fn eval_mapper<'a>(expression: Expression<'a>) -> StdResult<Expression<'a>, ()> 
     Ok(Expression::Eval(Box::new(expression)))
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an exit.
+
+        # Examples
+
+        ```
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal};
+        use tagua_parser::rules::expressions::primaries::intrinsic_exit;
+
+        # fn main () {
+        assert_eq!(
+            intrinsic_exit(b\"exit(7)\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Exit(
+                    Some(
+                        Box::new(
+                            Expression::Literal(
+                                Literal::Integer(7i64)
+                            )
+                        )
+                    )
+                )
+            )
+        );
+        # }
+        ```
+    "],
     pub intrinsic_exit<Expression>,
     map_res!(
         preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -538,7 +538,7 @@ fn into_unset<'a>(expressions: Vec<Expression<'a>>) -> Expression<'a> {
 }
 
 named!(
-    intrinsic_empty<Expression>,
+    pub intrinsic_empty<Expression>,
     map_res!(
         preceded!(
             keyword!(tokens::EMPTY),

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -123,7 +123,38 @@ fn literal_mapper<'a>(literal: Literal) -> Expression<'a> {
     Expression::Literal(literal)
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an array.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::{Expression, Literal, Variable};
+        use tagua_parser::rules::expressions::primaries::array;
+
+        # fn main () {
+        assert_eq!(
+            array(b\"[42, 'foo' => $bar]\"),
+            Result::Done(
+                &b\"\"[..],
+                Expression::Array(vec![
+                    (
+                        None,
+                        Expression::Literal(Literal::Integer(42i64))
+                    ),
+                    (
+                        Some(Expression::Literal(Literal::String(b\"foo\".to_vec()))),
+                        Expression::Variable(Variable(&b\"bar\"[..]))
+                    )
+                ])
+            )
+        );
+        # }
+        ```
+    "],
     pub array<Expression>,
     alt!(
         preceded!(

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -931,11 +931,9 @@ mod tests {
         let input  = b"echo /* baz */ 'foobar'";
         let output = Result::Done(
             &b""[..],
-            Expression::Echo(
-                vec![
-                    Expression::Literal(Literal::String(b"foobar".to_vec()))
-                ]
-            )
+            Expression::Echo(vec![
+                Expression::Literal(Literal::String(b"foobar".to_vec()))
+            ])
         );
 
         assert_eq!(intrinsic_echo(input), output);
@@ -949,13 +947,11 @@ mod tests {
         let input  = b"echo /* baz */ 'foobar',\t $bazqux, \n  42";
         let output = Result::Done(
             &b""[..],
-            Expression::Echo(
-                vec![
-                    Expression::Literal(Literal::String(b"foobar".to_vec())),
-                    Expression::Variable(Variable(&b"bazqux"[..])),
-                    Expression::Literal(Literal::Integer(42i64))
-                ]
-            )
+            Expression::Echo(vec![
+                Expression::Literal(Literal::String(b"foobar".to_vec())),
+                Expression::Variable(Variable(&b"bazqux"[..])),
+                Expression::Literal(Literal::Integer(42i64))
+            ])
         );
 
         assert_eq!(intrinsic_echo(input), output);

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -246,6 +246,8 @@ named_attr!(
     #[doc="
         Recognize an integer with the decimal notation.
 
+        If the integer is too large to fit in an `i64`, then it will be a `f64`.
+
         # Examples
 
         ```

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -366,12 +366,16 @@ named_attr!(
 pub enum StringError {
     /// The datum starts as a string but is too short to be a string.
     TooShort,
+
     /// The string open character is not correct.
     InvalidOpeningCharacter,
+
     /// The string close character is not correct.
     InvalidClosingCharacter,
+
     /// The string is not correctly encoded (expect UTF-8).
     InvalidEncoding,
+
     /// The string delimiter identifier is syntactically invalid.
     InvalidDelimiterIdentifier
 }

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -51,7 +51,25 @@ use super::super::internal::{
 };
 use super::tokens;
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all kind of literals.
+
+        A literal is either a null, a boolean, an expotential, an integer or an integer.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::literal;
+
+        # fn main () {
+        assert_eq!(literal(b\"0x2a\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        # }
+        ```
+    "],
     pub literal<Literal>,
     alt!(
         null

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -242,7 +242,23 @@ named_attr!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an integer with the decimal notation.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::decimal;
+
+        # fn main () {
+        assert_eq!(decimal(b\"42\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        # }
+        ```
+    "],
     pub decimal<Literal>,
     map_res!(
         re_bytes_find_static!(r"^[1-9][0-9]*"),

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -201,7 +201,23 @@ named_attr!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an integer with the octal notation.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::octal;
+
+        # fn main () {
+        assert_eq!(octal(b\"052\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        # }
+        ```
+    "],
     pub octal<Literal>,
     map_res!(
         preceded!(tag!("0"), opt!(complete!(oct_digit))),

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -90,10 +90,10 @@ named_attr!(
         # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
-        use tagua_parser::rules::literals::literal;
+        use tagua_parser::rules::literals::null;
 
         # fn main () {
-        assert_eq!(literal(b\"null\"), Result::Done(&b\"\"[..], Literal::Null));
+        assert_eq!(null(b\"null\"), Result::Done(&b\"\"[..], Literal::Null));
         # }
         ```
     "],

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -106,7 +106,23 @@ named_attr!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a boolean.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::boolean;
+
+        # fn main () {
+        assert_eq!(boolean(b\"true\"), Result::Done(&b\"\"[..], Literal::Boolean(true)));
+        # }
+        ```
+    "],
     pub boolean<Literal>,
     map_res!(
         alt!(itag!(&b"true"[..]) | itag!(&b"false"[..])),

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -160,7 +160,23 @@ named_attr!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an integer with the binary notation.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::binary;
+
+        # fn main () {
+        assert_eq!(binary(b\"0b101010\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        # }
+        ```
+    "],
     pub binary<Literal>,
     map_res!(
         preceded!(
@@ -179,7 +195,7 @@ named!(
                 .and_then(
                     |binary| {
                         Ok(Literal::Integer(binary))
-                   }
+                    }
                 )
         }
     )

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -132,7 +132,25 @@ named_attr!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an integer.
+
+        An integer is either a binary, a decimal, an hexadecimal or an octal representation.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::integer;
+
+        # fn main () {
+        assert_eq!(integer(b\"0b101010\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        # }
+        ```
+    "],
     pub integer<Literal>,
     alt_complete!(
         binary

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -289,7 +289,23 @@ named_attr!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize an integer with the hexadecimal notation.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::decimal;
+
+        # fn main () {
+        assert_eq!(decimal(b\"42\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        # }
+        ```
+    "],
     pub hexadecimal<Literal>,
     map_res!(
         preceded!(

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -380,7 +380,26 @@ pub enum StringError {
     InvalidDelimiterIdentifier
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all kind of strings.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::string;
+
+        # fn main () {
+        assert_eq!(
+            string(b\"'foobar'\"),
+            Result::Done(&b\"\"[..], Literal::String(b\"foobar\".to_vec()))
+        );
+        # }
+        ```
+    "],
     pub string<Literal>,
     alt!(
         string_single_quoted

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -80,7 +80,23 @@ named_attr!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a null value.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::literal;
+
+        # fn main () {
+        assert_eq!(literal(b\"null\"), Result::Done(&b\"\"[..], Literal::Null));
+        # }
+        ```
+    "],
     pub null<Literal>,
     map_res!(
         itag!("null"),

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -330,7 +330,23 @@ named_attr!(
     )
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a real with the exponential notation.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Literal;
+        use tagua_parser::rules::literals::exponential;
+
+        # fn main () {
+        assert_eq!(exponential(b\"123.456e+78\"), Result::Done(&b\"\"[..], Literal::Real(123.456e78f64)));
+        # }
+        ```
+    "],
     pub exponential<Literal>,
     map_res!(
         re_bytes_find_static!(r"^(([0-9]*\.[0-9]+|[0-9]+\.)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)"),

--- a/source/rules/skip.rs
+++ b/source/rules/skip.rs
@@ -38,7 +38,28 @@
 use super::comments::comment;
 use super::whitespaces::whitespace;
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all tokens to skip.
+
+        A skip token is a token that is not relevant for the understanding of
+        the language. It is present for comestic reasons only.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::rules::skip::skip;
+
+        # fn main () {
+        assert_eq!(
+            skip(b\"/* foo */ \\n\\thello\"),
+            Result::Done(&b\"hello\"[..], vec![&b\" foo \"[..], &b\" \\n\\t\"[..]])
+        );
+        # }
+        ```
+    "],
     pub skip< Vec<&[u8]> >,
     many0!(
         alt!(

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -142,7 +142,22 @@ fn wrap_into_vector_mapper(string: &[u8]) -> Result<Vec<&[u8]>, ()> {
     Ok(vec![string])
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a name.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::rules::tokens::name;
+
+        # fn main () {
+        assert_eq!(name(b\"foo\"), Result::Done(&b\"\"[..], &b\"foo\"[..]));
+        # }
+        ```
+    "],
     pub name,
     re_bytes_find_static!(r"^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*")
 );

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -59,26 +59,28 @@ fn variable_mapper(string: &[u8]) -> Result<Variable, ()> {
 
 named!(
     pub qualified_name<Name>,
-    chain!(
-        head: alt!(
-            tag!(tokens::NAMESPACE_SEPARATOR)
-          | terminated!(
-                keyword!(tokens::NAMESPACE),
-                first!(tag!(tokens::NAMESPACE_SEPARATOR))
+    do_parse!(
+        head: opt!(
+            alt!(
+                tag!(tokens::NAMESPACE_SEPARATOR)
+              | terminated!(
+                    keyword!(tokens::NAMESPACE),
+                    first!(tag!(tokens::NAMESPACE_SEPARATOR))
+                )
             )
-        )? ~
+        ) >>
         accumulator: map_res!(
             exclude!(first!(name), tokens::keywords),
             wrap_into_vector_mapper
-        ) ~
+        ) >>
         result: fold_into_vector_many0!(
             preceded!(
                 first!(tag!(tokens::NAMESPACE_SEPARATOR)),
                 exclude!(first!(name), tokens::keywords)
             ),
             accumulator
-        ),
-        || {
+        ) >>
+        (
             match head {
                 Some(handle) => {
                     if handle == tokens::NAMESPACE_SEPARATOR {
@@ -96,7 +98,7 @@ named!(
                     }
                 }
             }
-        }
+        )
     )
 );
 

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -41,7 +41,23 @@ use super::super::ast::{
 };
 use super::super::tokens;
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a variable.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Variable;
+        use tagua_parser::rules::tokens::variable;
+
+        # fn main () {
+        assert_eq!(variable(b\"$foo\"), Result::Done(&b\"\"[..], Variable(&b\"foo\"[..])));
+        # }
+        ```
+    "],
     pub variable<Variable>,
     map_res!(
         preceded!(

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -73,7 +73,26 @@ fn variable_mapper(string: &[u8]) -> Result<Variable, ()> {
     Ok(Variable(string))
 }
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a qualified name.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::ast::Name;
+        use tagua_parser::rules::tokens::qualified_name;
+
+        # fn main () {
+        assert_eq!(
+            qualified_name(b\"Foo\\\\Bar\\\\Baz\"),
+            Result::Done(&b\"\"[..], Name::Qualified(vec![&b\"Foo\"[..], &b\"Bar\"[..], &b\"Baz\"[..]]))
+       );
+        # }
+        ```
+    "],
     pub qualified_name<Name>,
     do_parse!(
         head: opt!(

--- a/source/rules/whitespaces.rs
+++ b/source/rules/whitespaces.rs
@@ -35,7 +35,22 @@
 //! in the [Grammar chapter, White Space
 //! section](https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#white-space).
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all whitespaces.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::rules::whitespaces::whitespace;
+
+        # fn main () {
+        assert_eq!(whitespace(b\"\\n \\r\\tabc\"), Result::Done(&b\"abc\"[..], &b\"\\n \\r\\t\"[..]));
+        # }
+        ```
+    "],
     pub whitespace,
     is_a!(" \t\n\r")
 );

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -646,11 +646,11 @@ named!(
       | keyword!(VAR)
       | keyword!(WHILE)
       | keyword!(XOR)
-      | chain!(
-            keyword!("yield") ~
-            whitespace ~
-            keyword!("from"),
-            || { YIELD_FROM }
+      | do_parse!(
+            keyword!("yield") >>
+            whitespace >>
+            keyword!("from") >>
+            (YIELD_FROM)
         )
       | keyword!(YIELD)
     )

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -578,7 +578,28 @@ token!(
     "The `QUESTION_MARK` private token.\n\nSee `NULLABLE` and `TERNARY_THEN`."
 );
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize all keywords.
+
+        Note that most PHP keywords are case-insensitives. This parser satisfies this constraint.
+
+        # Examples
+
+        ```
+        # extern crate tagua_parser;
+        use tagua_parser::Result;
+        use tagua_parser::tokens;
+
+        # fn main () {
+        let output = Result::Done(&b\"\"[..], tokens::ECHO);
+
+        assert_eq!(tokens::keywords(b\"echo\"), output);
+        assert_eq!(tokens::keywords(b\"ECHO\"), output);
+        assert_eq!(tokens::keywords(b\"EcHo\"), output);
+        # }
+        ```
+    "],
     pub keywords,
     alt_complete!(
         keyword!(ABSTRACT)


### PR DESCRIPTION
Follow up of #83.
Fix #85.

### Progression

* [x] `chain!` has been deprecated in favor of `do_parse!`,
* [x] Replace `named!` by `named_attr!`, see https://github.com/tagua-vm/parser/issues/85,
* [ ] Replace `first!` by `nom::sep!` or `nom::eat_separator!`, see https://github.com/tagua-vm/parser/issues/84 **postponed**.