### PR TITLE
CI: Update Rust versions, and remove travis-cargo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,20 @@ language: rust
 
 matrix:
   include:
-    - rust: 1.9.0
+    - rust: 1.13.0
       os: linux
       dist: trusty
-    - rust: 1.9.0
+    - rust: 1.13.0
       os: osx
-    - rust: 1.10.0
+    - rust: 1.14.0
       os: linux
       dist: trusty
-    - rust: 1.10.0
+    - rust: 1.14.0
       os: osx
-    - rust: 1.11.0
+    - rust: 1.15.0
       os: linux
       dist: trusty
-    - rust: 1.11.0
-      os: osx
-    - rust: 1.12.0
-      os: linux
-      dist: trusty
-    - rust: 1.12.0
+    - rust: 1.15.0
       os: osx
     - rust: stable
       os: linux
@@ -44,13 +39,6 @@ matrix:
 cache: cargo
 
 sudo: false
-addons:
-  apt:
-    packages:
-      - libcurl4-openssl-dev
-      - libdw-dev
-      - libdw1
-      - libelf-dev
 
 env:
   global:
@@ -59,20 +47,6 @@ env:
 notifications:
   irc: "chat.freenode.net#taguavm"
 
-before_script:
-  - |
-      pip install 'travis-cargo<0.2' --user &&
-      export PATH="$HOME/.local/bin:$HOME/Library/Python/2.7/bin:$PATH"
-
 script:
-  - |
-      travis-cargo build &&
-      travis-cargo test &&
-      travis-cargo --only stable doc
-
-after_success:
-  - |
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-          travis-cargo --only stable doc-upload;
-          travis-cargo coveralls --no-sudo;
-      fi
+  - cargo build
+  - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ debug-assertions = true
 codegen-units    = 1
 
 [dependencies]
-lazy_static = "~0.1"
-regex       = "~0.1"
+lazy_static = "~0.2"
+regex       = "~0.2"
 
 [dependencies.nom]
-version  = "^2.0.0"
+version  = "~2.2"
 features = ["regexp", "regexp_macros", "verbose-errors"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ available](https://waffle.io/tagua-vm/parser).
 ## Documentation and help
 
 The documentation is automatically uploaded online at the following address:
-https://tagua-vm.github.io/parser.
+https://docs.rs/tagua-parser/*/tagua_parser/.
 
 To generate it locally, please, run the following command:
 
@@ -97,7 +97,7 @@ Tagua VM is under the New BSD License (BSD-3-Clause):
 
 
 
-Copyright © 2016-2016, Ivan Enderlin.
+Copyright © 2016-2017, Ivan Enderlin.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/internal.rs
+++ b/source/internal.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -5,7 +5,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/macros.rs
+++ b/source/macros.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/comments.rs
+++ b/source/rules/comments.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/expressions/constant.rs
+++ b/source/rules/expressions/constant.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/expressions/mod.rs
+++ b/source/rules/expressions/mod.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -263,7 +263,7 @@ named_attr!(
     "],
     pub decimal<Literal>,
     map_res!(
-        re_bytes_find_static!(r"^[1-9][0-9]*"),
+        re_bytes_find_static!(r"(?-u)^[1-9][0-9]*"),
         |bytes: &[u8]| {
             let string = unsafe { str::from_utf8_unchecked(bytes) };
 
@@ -349,7 +349,7 @@ named_attr!(
     "],
     pub exponential<Literal>,
     map_res!(
-        re_bytes_find_static!(r"^(([0-9]*\.[0-9]+|[0-9]+\.)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)"),
+        re_bytes_find_static!(r"(?-u)^(([0-9]*\.[0-9]+|[0-9]+\.)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)"),
         |bytes: &[u8]| {
             f64
                 ::from_str(unsafe { str::from_utf8_unchecked(bytes) })

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/mod.rs
+++ b/source/rules/mod.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/skip.rs
+++ b/source/rules/skip.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/statements/function.rs
+++ b/source/rules/statements/function.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/statements/mod.rs
+++ b/source/rules/statements/mod.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -159,7 +159,7 @@ named_attr!(
         ```
     "],
     pub name,
-    re_bytes_find_static!(r"^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*")
+    re_bytes_find_static!(r"(?-u)^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*")
 );
 
 

--- a/source/rules/whitespaces.rs
+++ b/source/rules/whitespaces.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -3,7 +3,7 @@
 //
 // New BSD License
 //
-// Copyright © 2016-2016, Ivan Enderlin.
+// Copyright © 2016-2017, Ivan Enderlin.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Update Rust versions.
Drop Rust 1.9, too old, only required for travis-cargo, but it is abandonned. Until then, drop coverage, and embrace newer Rust versions and shorter build time.

Also drop doc', since doc.rs.