### PR TITLE
CI: Use `cargo-travis`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,17 @@ cache: cargo
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - binutils-dev
+      - cmake
+      - libcurl4-openssl-dev
+      - libdw-dev
+      - libelf-dev
+    sources:
+      - kalakris-cmake
+
 env:
   global:
     secure: nDy6lalxkiPOkM1zvCjkdPhi8OK+k8Ac6MlcIDWUyw/GccSda9BkOZ4nQuGx3xwjsMjaZ6M81r2p8jne6Fc89DfjtpgWNZ7BlShLHSQgT86vcuT3f92OjLySJawEGHQGpndfzoBbySVghTfTfiCQdphrniHdDw9vvo/f70L8L17/JeVVM5lUQmekDlbBLLugWg4e2U1aBi6czZwZhqHhuAvU2rXP6tDx3PNU97tTDFF2Xxt0FjdrcAtweVSr8jOIArtHpy8/EXFgJZYzkRxitVCMEb5MU1Ddpttsoj7Sdg2f0Cpv7r5PPvTc1qnGWcWKb+xWjo3GtHrpQFI/6InWVEF8ytEyqX1VwQSOMG+9W2Rwns35xGMuPzCaJusmIohFc0XRN9wB6+SeH1mbx2QXpdcdPrepzaHZ9s+Dj5VbcJ+5dYaRiI7sIQSZ337bxLuHIH79k9ztMU3kS2U0oTJFIE/CZAJ9mrgZJ6Dc2lI/p0b5HR7Avj83KTVU+OiPL4abcX5j8PQQpIoF+RWj62+eTPqU+X5vgFA2eQeX8NKWE9Gb/t9YrD5KTebhTnLIOCLOOyZKz41VRy9q4M2kdFj1NqGe2SQazSA558jtC1kEoDgfuVNiVDiak/Hn8Cc8+eI7/9Hr6ykU5mvgl9xTY/a+olbTN3AyesxXnJVU8mdvLgc=
@@ -50,3 +61,16 @@ notifications:
 script:
   - cargo build
   - cargo test
+
+before_script:
+  - |
+      cargo install cargo-travis &&
+      export PATH=$HOME/.cargo/bin:$PATH
+
+script:
+  - |
+      cargo build &&
+      cargo test
+
+after_success:
+  - cargo coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
 
 before_script:
   - |
-      cargo install cargo-travis &&
+      cargo install --force cargo-travis &&
       export PATH=$HOME/.cargo/bin:$PATH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,4 +73,7 @@ script:
       cargo test
 
 after_success:
-  - cargo coveralls
+  - |
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+          cargo coveralls;
+      fi


### PR DESCRIPTION
`travis-cargo` is assumed dead. We have removed it in #98. Now we are restoring the missing features with the help of `cargo-travis`.