### PR TITLE
Introduce `Token` and `Span`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,15 @@ lto              = false
 debug-assertions = true
 codegen-units    = 1
 
+[features]
+simd = ["bytecount/simd-accel"]
+avx  = ["bytecount/avx-accel"]
+
 [dependencies]
 lazy_static = "~0.2"
 regex       = "~0.2"
+bytecount   = "~0.1"
+memchr      = "~1.0"
 
 [dependencies.nom]
 version  = "~2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,14 @@ lto              = false
 debug-assertions = true
 codegen-units    = 1
 
+[profile.bench]
+opt-level        = 3
+debug            = false
+rpath            = false
+lto              = true
+debug-assertions = false
+codegen-units    = 1
+
 [features]
 simd = ["bytecount/simd-accel"]
 avx  = ["bytecount/avx-accel"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ To build a development version:
 $ cargo build
 ```
 
+If you have SIMD or AVX on your hardware, then, you can respectively
+use the `simd` or `avx` feature as follows:
+
+```sh
+$ cargo build --release --features simd
+```
+
 ### Using Docker
 
 If installing Rust on your machine is too much, Docker might be an alternative:

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -31,25 +31,30 @@
 
 //! Structures that will constitute the Abstract Syntax Tree.
 
+use super::tokens::{
+    Span,
+    Token
+};
+
 /// A term.
 #[derive(Debug, PartialEq)]
-pub struct Term {
+pub struct Term<'a> {
     /// The term value.
-    pub t: Literal
+    pub t: Literal<'a>
 }
 
 /// An addition of two terms.
 #[derive(Debug, PartialEq)]
-pub struct Addition {
+pub struct Addition<'a> {
     /// The left-hand side of the addition.
-    pub a: Term,
+    pub a: Term<'a>,
     /// The right-hand side of the addition.
-    pub b: Term
+    pub b: Term<'a>
 }
 
 /// A literal represents a fixed value, aka an atom.
 #[derive(Debug, PartialEq)]
-pub enum Literal {
+pub enum Literal<'a> {
     /// A boolean, either `true` or `false`.
     ///
     /// # Examples
@@ -65,7 +70,7 @@ pub enum Literal {
     /// assert_eq!(literal(b"false"), Result::Done(&b""[..], Literal::Boolean(false)));
     /// # }
     /// ```
-    Boolean(bool),
+    Boolean(Token<'a, bool>),
 
     /// An integer, for instance a binary, octal, decimal or hexadecimal number.
     ///
@@ -86,7 +91,7 @@ pub enum Literal {
     /// assert_eq!(literal(b"0x2a"), output);
     /// # }
     /// ```
-    Integer(i64),
+    Integer(Token<'a, i64>),
 
     /// A null value.
     ///
@@ -102,7 +107,7 @@ pub enum Literal {
     /// assert_eq!(literal(b"null"), Result::Done(&b""[..], Literal::Null));
     /// # }
     /// ```
-    Null,
+    Null(Token<'a, ()>),
 
     /// A real, for instance an exponential number.
     ///
@@ -122,7 +127,7 @@ pub enum Literal {
     /// assert_eq!(literal(b"420e-2"), output);
     /// # }
     /// ```
-    Real(f64),
+    Real(Token<'a, f64>),
 
     /// A string.
     ///
@@ -141,7 +146,7 @@ pub enum Literal {
     /// );
     /// # }
     /// ```
-    String(Vec<u8>)
+    String(Token<'a, Vec<u8>>)
 }
 
 /// A variable.
@@ -163,7 +168,7 @@ pub enum Literal {
 /// ```
 /// Note that the `$` is not present.
 #[derive(Debug, PartialEq)]
-pub struct Variable<'a>(pub &'a [u8]);
+pub struct Variable<'a>(pub Span<'a>);
 
 /// A name represents an entity name.
 #[derive(Debug, PartialEq)]
@@ -185,7 +190,7 @@ pub enum Name<'a> {
     /// );
     /// # }
     /// ```
-    Unqualified(&'a [u8]),
+    Unqualified(Span<'a>),
 
     /// A qualified name, i.e. a name in a relative namespace (aliased or not),
     /// like `Foo\Bar`.
@@ -205,7 +210,7 @@ pub enum Name<'a> {
     /// );
     /// # }
     /// ```
-    Qualified(Vec<&'a [u8]>),
+    Qualified(Vec<Span<'a>>),
 
     /// A relative qualified name, i.e. a name in a relative namespace
     /// restricted to the current namespace, like `namespace\Foo\Bar`.
@@ -226,7 +231,7 @@ pub enum Name<'a> {
     /// # }
     /// ```
     /// Note that the `namespace` part is not present.
-    RelativeQualified(Vec<&'a [u8]>),
+    RelativeQualified(Vec<Span<'a>>),
 
     /// A fully qualified name, i.e. a name in an absolute namespace, like
     /// `\Foo\Bar`.
@@ -247,7 +252,7 @@ pub enum Name<'a> {
     /// # }
     /// ```
     /// Note that the leading `\` part is not present.
-    FullyQualified(Vec<&'a [u8]>)
+    FullyQualified(Vec<Span<'a>>)
 }
 
 /// An expression.
@@ -571,7 +576,7 @@ pub enum Expression<'a> {
     /// );
     /// # }
     /// ```
-    Literal(Literal),
+    Literal(Literal<'a>),
 
     /// A name.
     ///
@@ -973,7 +978,7 @@ pub enum Arity<'a> {
 #[derive(Debug, PartialEq)]
 pub struct Function<'a> {
     /// Name of the function.
-    pub name: &'a [u8],
+    pub name: Span<'a>,
 
     /// Inputs, aka parameters, of the function.
     pub inputs: Arity<'a>,

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -64,10 +64,26 @@ pub enum Literal<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
     /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
-    /// assert_eq!(literal(b"true"),  Result::Done(&b""[..], Literal::Boolean(true)));
-    /// assert_eq!(literal(b"false"), Result::Done(&b""[..], Literal::Boolean(false)));
+    /// assert_eq!(
+    ///     literal(Span::new(b"true")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 4, 1, 5),
+    ///         Literal::Boolean(Token::new(true, Span::new(b"true")))
+    ///     )
+    /// );
+    /// assert_eq!(
+    ///     literal(Span::new(b"false")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 5, 1, 6),
+    ///         Literal::Boolean(Token::new(false, Span::new(b"false")))
+    ///     )
+    /// );
     /// # }
     /// ```
     Boolean(Token<'a, bool>),
@@ -81,14 +97,40 @@ pub enum Literal<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
     /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
-    /// let output = Result::Done(&b""[..], Literal::Integer(42i64));
-    ///
-    /// assert_eq!(literal(b"0b101010"), output);
-    /// assert_eq!(literal(b"052"), output);
-    /// assert_eq!(literal(b"42"), output);
-    /// assert_eq!(literal(b"0x2a"), output);
+    /// assert_eq!(
+    ///     literal(Span::new(b"0b101010")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 8, 1, 9),
+    ///         Literal::Integer(Token::new(42, Span::new(b"0b101010")))
+    ///     )
+    /// );
+    /// assert_eq!(
+    ///     literal(Span::new(b"052")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 3, 1, 4),
+    ///         Literal::Integer(Token::new(42, Span::new(b"052")))
+    ///     )
+    /// );
+    /// assert_eq!(
+    ///     literal(Span::new(b"42")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 2, 1, 3),
+    ///         Literal::Integer(Token::new(42, Span::new(b"42")))
+    ///     )
+    /// );
+    /// assert_eq!(
+    ///     literal(Span::new(b"0x2a")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 4, 1, 5),
+    ///         Literal::Integer(Token::new(42, Span::new(b"0x2a")))
+    ///     )
+    /// );
     /// # }
     /// ```
     Integer(Token<'a, i64>),
@@ -102,9 +144,19 @@ pub enum Literal<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
     /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
-    /// assert_eq!(literal(b"null"), Result::Done(&b""[..], Literal::Null));
+    /// assert_eq!(
+    ///     literal(Span::new(b"null")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 4, 1, 5),
+    ///         Literal::Null(Token::new((), Span::new(b"null")))
+    ///     )
+    /// );
     /// # }
     /// ```
     Null(Token<'a, ()>),
@@ -118,13 +170,33 @@ pub enum Literal<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
     /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
-    /// let output = Result::Done(&b""[..], Literal::Real(4.2f64));
-    ///
-    /// assert_eq!(literal(b"4.2"), output);
-    /// assert_eq!(literal(b".42e1"), output);
-    /// assert_eq!(literal(b"420e-2"), output);
+    /// assert_eq!(
+    ///     literal(Span::new(b"4.2")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 3, 1, 4),
+    ///         Literal::Real(Token::new(4.2f64, Span::new(b"4.2")))
+    ///     )
+    /// );
+    /// assert_eq!(
+    ///     literal(Span::new(b".42e1")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 5, 1, 6),
+    ///         Literal::Real(Token::new(4.2f64, Span::new(b".42e1")))
+    ///     )
+    /// );
+    /// assert_eq!(
+    ///     literal(Span::new(b"420e-2")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 6, 1, 7),
+    ///         Literal::Real(Token::new(4.2f64, Span::new(b"420e-2")))
+    ///     )
+    /// );
     /// # }
     /// ```
     Real(Token<'a, f64>),
@@ -138,11 +210,18 @@ pub enum Literal<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
     /// use tagua_parser::rules::literals::literal;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     literal(b"'foo\\'bar'"),
-    ///     Result::Done(&b""[..], Literal::String(b"foo'bar".to_vec()))
+    ///     literal(Span::new(b"'foo\\'bar'")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 10, 1, 11),
+    ///         Literal::String(Token::new(b"foo'bar".to_vec(), Span::new(b"'foo\\'bar'")))
+    ///     )
     /// );
     /// # }
     /// ```
@@ -158,11 +237,18 @@ pub enum Literal<'a> {
 /// use tagua_parser::Result;
 /// use tagua_parser::ast::Variable;
 /// use tagua_parser::rules::tokens::variable;
+/// use tagua_parser::tokens::{
+///     Span,
+///     Token
+/// };
 ///
 /// # fn main() {
 /// assert_eq!(
-///     variable(b"$foo"),
-///     Result::Done(&b""[..], Variable(&b"foo"[..]))
+///     variable(Span::new(b"$foo")),
+///     Result::Done(
+///         Span::new_at(b"", 4, 1, 5),
+///         Variable(Span::new_at(b"foo", 1, 1, 2))
+///     )
 /// );
 /// # }
 /// ```
@@ -182,11 +268,18 @@ pub enum Name<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
     /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     qualified_name(b"Bar"),
-    ///     Result::Done(&b""[..], Name::Unqualified(&b"Bar"[..]))
+    ///     qualified_name(Span::new(b"Bar")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 3, 1, 4),
+    ///         Name::Unqualified(Span::new(b"Bar"))
+    ///     )
     /// );
     /// # }
     /// ```
@@ -202,11 +295,21 @@ pub enum Name<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
     /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     qualified_name(b"Foo\\Bar"),
-    ///     Result::Done(&b""[..], Name::Qualified(vec![&b"Foo"[..], &b"Bar"[..]]))
+    ///     qualified_name(Span::new(b"Foo\\Bar")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 7, 1, 8),
+    ///         Name::Qualified(vec![
+    ///             Span::new(b"Foo"),
+    ///             Span::new_at(b"Bar", 4, 1, 5)
+    ///         ])
+    ///     )
     /// );
     /// # }
     /// ```
@@ -222,11 +325,21 @@ pub enum Name<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
     /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     qualified_name(b"namespace\\Foo\\Bar"),
-    ///     Result::Done(&b""[..], Name::RelativeQualified(vec![&b"Foo"[..], &b"Bar"[..]]))
+    ///     qualified_name(Span::new(b"namespace\\Foo\\Bar")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 17, 1, 18),
+    ///         Name::RelativeQualified(vec![
+    ///             Span::new_at(b"Foo", 10, 1, 11),
+    ///             Span::new_at(b"Bar", 14, 1, 15)
+    ///         ])
+    ///     )
     /// );
     /// # }
     /// ```
@@ -243,11 +356,21 @@ pub enum Name<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
     /// use tagua_parser::rules::tokens::qualified_name;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     qualified_name(b"\\Foo\\Bar"),
-    ///     Result::Done(&b""[..], Name::FullyQualified(vec![&b"Foo"[..], &b"Bar"[..]]))
+    ///     qualified_name(Span::new(b"\\Foo\\Bar")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 8, 1, 9),
+    ///         Name::FullyQualified(vec![
+    ///             Span::new_at(b"Foo", 1, 1, 2),
+    ///             Span::new_at(b"Bar", 5, 1, 6)
+    ///         ])
+    ///     )
     /// );
     /// # }
     /// ```
@@ -279,29 +402,33 @@ pub enum Expression<'a> {
     ///     Variable
     /// };
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"function (I $x, J &$y) use ($z): O { return; }"),
+    ///     expression(Span::new(b"function (I $x, J &$y) use ($z): O { return; }")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 46, 1, 47),
     ///         Expression::AnonymousFunction(
     ///             AnonymousFunction {
     ///                 declaration_scope: Scope::Dynamic,
     ///                 inputs           : Arity::Finite(vec![
     ///                     Parameter {
-    ///                         ty   : Ty::Copy(Some(Name::Unqualified(&b"I"[..]))),
-    ///                         name : Variable(&b"x"[..]),
+    ///                         ty   : Ty::Copy(Some(Name::Unqualified(Span::new_at(b"I", 10, 1, 11)))),
+    ///                         name : Variable(Span::new_at(b"x", 13, 1, 14)),
     ///                         value: None
     ///                     },
     ///                     Parameter {
-    ///                         ty   : Ty::Reference(Some(Name::Unqualified(&b"J"[..]))),
-    ///                         name : Variable(&b"y"[..]),
+    ///                         ty   : Ty::Reference(Some(Name::Unqualified(Span::new_at(b"J", 16, 1, 17)))),
+    ///                         name : Variable(Span::new_at(b"y", 20, 1, 21)),
     ///                         value: None
     ///                     }
     ///                 ]),
-    ///                 output         : Ty::Copy(Some(Name::Unqualified(&b"O"[..]))),
-    ///                 enclosing_scope: Some(vec![Expression::Variable(Variable(&b"z"[..]))]),
+    ///                 output         : Ty::Copy(Some(Name::Unqualified(Span::new_at(b"O", 33, 1, 34)))),
+    ///                 enclosing_scope: Some(vec![Expression::Variable(Variable(Span::new_at(b"z", 29, 1, 30)))]),
     ///                 body           : vec![Statement::Return]
     ///             }
     ///         )
@@ -321,24 +448,28 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"['foo', 42 => 'bar', 'baz' => $qux]"),
+    ///     expression(Span::new(b"['foo', 42 => 'bar', 'baz' => $qux]")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 35, 1, 36),
     ///         Expression::Array(vec![
     ///             (
     ///                 None,
-    ///                 Expression::Literal(Literal::String(b"foo".to_vec()))
+    ///                 Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 1, 1, 2))))
     ///             ),
     ///             (
-    ///                 Some(Expression::Literal(Literal::Integer(42i64))),
-    ///                 Expression::Literal(Literal::String(b"bar".to_vec()))
+    ///                 Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 8, 1, 9))))),
+    ///                 Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 14, 1, 15))))
     ///             ),
     ///             (
-    ///                 Some(Expression::Literal(Literal::String(b"baz".to_vec()))),
-    ///                 Expression::Variable(Variable(&b"qux"[..]))
+    ///                 Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 21, 1, 22))))),
+    ///                 Expression::Variable(Variable(Span::new_at(b"qux", 31, 1, 32)))
     ///             )
     ///         ])
     ///     )
@@ -358,16 +489,20 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"echo 'foobar', $bazqux, 42"),
+    ///     expression(Span::new(b"echo 'foobar', $bazqux, 42")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 26, 1, 27),
     ///         Expression::Echo(vec![
-    ///             Expression::Literal(Literal::String(b"foobar".to_vec())),
-    ///             Expression::Variable(Variable(&b"bazqux"[..])),
-    ///             Expression::Literal(Literal::Integer(42i64))
+    ///             Expression::Literal(Literal::String(Token::new(b"foobar".to_vec(), Span::new_at(b"'foobar'", 5, 1, 6)))),
+    ///             Expression::Variable(Variable(Span::new_at(b"bazqux", 16, 1, 17))),
+    ///             Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 24, 1, 25))))
     ///         ])
     ///     )
     /// );
@@ -385,16 +520,20 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"empty('')"),
+    ///     expression(Span::new(b"empty('')")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 9, 1, 10),
     ///         Expression::Empty(
     ///             Box::new(
     ///                 Expression::Literal(
-    ///                     Literal::String(b"".to_vec())
+    ///                     Literal::String(Token::new(b"".to_vec(), Span::new_at(b"''", 6, 1, 7)))
     ///                 )
     ///             )
     ///         )
@@ -413,16 +552,20 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"eval('1 + 2;')"),
+    ///     expression(Span::new(b"eval('1 + 2;')")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 14, 1, 15),
     ///         Expression::Eval(
     ///             Box::new(
     ///                 Expression::Literal(
-    ///                     Literal::String(b"1 + 2;".to_vec())
+    ///                     Literal::String(Token::new(b"1 + 2;".to_vec(), Span::new_at(b"'1 + 2;'", 5, 1, 6)))
     ///                 )
     ///             )
     ///         )
@@ -441,17 +584,21 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"exit(42)"),
+    ///     expression(Span::new(b"exit(42)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 8, 1, 9),
     ///         Expression::Exit(
     ///             Some(
     ///                 Box::new(
     ///                     Expression::Literal(
-    ///                         Literal::Integer(42i64)
+    ///                         Literal::Integer(Token::new(42i64, Span::new_at(b"42", 5, 1, 6)))
     ///                     )
     ///                 )
     ///             )
@@ -472,15 +619,19 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"isset($foo, $bar)"),
+    ///     expression(Span::new(b"isset($foo, $bar)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 17, 1, 18),
     ///         Expression::Isset(vec![
-    ///             Expression::Variable(Variable(&b"foo"[..])),
-    ///             Expression::Variable(Variable(&b"bar"[..]))
+    ///             Expression::Variable(Variable(Span::new_at(b"foo", 7, 1, 8))),
+    ///             Expression::Variable(Variable(Span::new_at(b"bar", 13, 1, 14)))
     ///         ])
     ///     )
     /// );
@@ -500,24 +651,28 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"list('foo' => $foo, 'bar' => $bar, 'baz' => $baz)"),
+    ///     expression(Span::new(b"list('foo' => $foo, 'bar' => $bar, 'baz' => $baz)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 49, 1, 50),
     ///         Expression::List(vec![
     ///             Some((
-    ///                 Some(Expression::Literal(Literal::String(b"foo".to_vec()))),
-    ///                 Expression::Variable(Variable(&b"foo"[..]))
+    ///                 Some(Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 5, 1, 6))))),
+    ///                 Expression::Variable(Variable(Span::new_at(b"foo", 15, 1, 16)))
     ///             )),
     ///             Some((
-    ///                 Some(Expression::Literal(Literal::String(b"bar".to_vec()))),
-    ///                 Expression::Variable(Variable(&b"bar"[..]))
+    ///                 Some(Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 20, 1, 21))))),
+    ///                 Expression::Variable(Variable(Span::new_at(b"bar", 30, 1, 31)))
     ///             )),
     ///             Some((
-    ///                 Some(Expression::Literal(Literal::String(b"baz".to_vec()))),
-    ///                 Expression::Variable(Variable(&b"baz"[..]))
+    ///                 Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 35, 1, 36))))),
+    ///                 Expression::Variable(Variable(Span::new_at(b"baz", 45, 1, 46)))
     ///             ))
     ///         ])
     ///     )
@@ -531,26 +686,30 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"list($foo, , , $bar, $baz)"),
+    ///     expression(Span::new(b"list($foo, , , $bar, $baz)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 26, 1, 27),
     ///         Expression::List(vec![
     ///             Some((
     ///                 None,
-    ///                 Expression::Variable(Variable(&b"foo"[..]))
+    ///                 Expression::Variable(Variable(Span::new_at(b"foo", 6, 1, 7)))
     ///             )),
     ///             None,
     ///             None,
     ///             Some((
     ///                 None,
-    ///                 Expression::Variable(Variable(&b"bar"[..]))
+    ///                 Expression::Variable(Variable(Span::new_at(b"bar", 16, 1, 17)))
     ///             )),
     ///             Some((
     ///                 None,
-    ///                 Expression::Variable(Variable(&b"baz"[..]))
+    ///                 Expression::Variable(Variable(Span::new_at(b"baz", 22, 1, 23)))
     ///             ))
     ///         ])
     ///     )
@@ -568,11 +727,18 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"'Hello, World!'"),
-    ///     Result::Done(&b""[..], Expression::Literal(Literal::String(b"Hello, World!".to_vec())))
+    ///     expression(Span::new(b"'Hello, World!'")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 15, 1, 16),
+    ///         Expression::Literal(Literal::String(Token::new(b"Hello, World!".to_vec(), Span::new(b"'Hello, World!'"))))
+    ///     )
     /// );
     /// # }
     /// ```
@@ -587,11 +753,23 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Name};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"Foo\\Bar"),
-    ///     Result::Done(&b""[..], Expression::Name(Name::Qualified(vec![&b"Foo"[..], &b"Bar"[..]])))
+    ///     expression(Span::new(b"Foo\\Bar")),
+    ///     Result::Done(
+    ///         Span::new_at(b"", 7, 1, 8),
+    ///         Expression::Name(
+    ///             Name::Qualified(vec![
+    ///                 Span::new(b"Foo"),
+    ///                 Span::new_at(b"Bar", 4, 1, 5)
+    ///             ])
+    ///         )
+    ///     )
     /// );
     /// # }
     /// ```
@@ -607,15 +785,19 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"print $foo"),
+    ///     expression(Span::new(b"print $foo")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 10, 1, 11),
     ///         Expression::Print(
     ///             Box::new(
-    ///                 Expression::Variable(Variable(&b"foo"[..])),
+    ///                 Expression::Variable(Variable(Span::new_at(b"foo", 7, 1, 8))),
     ///             )
     ///         )
     ///     )
@@ -633,17 +815,21 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"[7 => &$foo]"),
+    ///     expression(Span::new(b"[7 => &$foo]")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 12, 1, 13),
     ///         Expression::Array(vec![
     ///             (
-    ///                 Some(Expression::Literal(Literal::Integer(7i64))),
+    ///                 Some(Expression::Literal(Literal::Integer(Token::new(7i64, Span::new_at(b"7", 1, 1, 2))))),
     ///                 Expression::Reference(
-    ///                     Box::new(Expression::Variable(Variable(&b"foo"[..])))
+    ///                     Box::new(Expression::Variable(Variable(Span::new_at(b"foo", 8, 1, 9))))
     ///                 )
     ///             )
     ///         ])
@@ -662,15 +848,19 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"unset($foo, $bar)"),
+    ///     expression(Span::new(b"unset($foo, $bar)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 17, 1, 18),
     ///         Expression::Unset(vec![
-    ///             Expression::Variable(Variable(&b"foo"[..])),
-    ///             Expression::Variable(Variable(&b"bar"[..]))
+    ///             Expression::Variable(Variable(Span::new_at(b"foo", 7, 1, 8))),
+    ///             Expression::Variable(Variable(Span::new_at(b"bar", 13, 1, 14)))
     ///         ])
     ///     )
     /// );
@@ -687,11 +877,15 @@ pub enum Expression<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Variable};
     /// use tagua_parser::rules::expressions::expression;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     expression(b"$foo"),
-    ///     Result::Done(&b""[..], Expression::Variable(Variable(&b"foo"[..])))
+    ///     expression(Span::new(b"$foo")),
+    ///     Result::Done(Span::new_at(b"", 4, 1, 5), Expression::Variable(Variable(Span::new_at(b"foo", 1, 1, 2))))
     /// );
     /// # }
     /// ```
@@ -726,16 +920,20 @@ pub enum Ty<'a> {
     ///     Variable
     /// };
     /// use tagua_parser::rules::statements::function::parameters;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     parameters(b"(I $x)"),
+    ///     parameters(Span::new(b"(I $x)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 6, 1, 7),
     ///         Arity::Finite(vec![
     ///             Parameter {
-    ///                 ty   : Ty::Copy(Some(Name::Unqualified(&b"I"[..]))),
-    ///                 name : Variable(&b"x"[..]),
+    ///                 ty   : Ty::Copy(Some(Name::Unqualified(Span::new_at(b"I", 1, 1, 2)))),
+    ///                 name : Variable(Span::new_at(b"x", 4, 1, 5)),
     ///                 value: None
     ///             }
     ///         ])
@@ -760,16 +958,20 @@ pub enum Ty<'a> {
     ///     Variable
     /// };
     /// use tagua_parser::rules::statements::function::parameters;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     parameters(b"(I &$x)"),
+    ///     parameters(Span::new(b"(I &$x)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 7, 1, 8),
     ///         Arity::Finite(vec![
     ///             Parameter {
-    ///                 ty   : Ty::Reference(Some(Name::Unqualified(&b"I"[..]))),
-    ///                 name : Variable(&b"x"[..]),
+    ///                 ty   : Ty::Reference(Some(Name::Unqualified(Span::new_at(b"I", 1, 1, 2)))),
+    ///                 name : Variable(Span::new_at(b"x", 5, 1, 6)),
     ///                 value: None
     ///             }
     ///         ])
@@ -802,21 +1004,25 @@ pub enum Ty<'a> {
 ///     Variable
 /// };
 /// use tagua_parser::rules::statements::function::parameters;
+/// use tagua_parser::tokens::{
+///     Span,
+///     Token
+/// };
 ///
 /// # fn main() {
 /// assert_eq!(
-///     parameters(b"($x = 42, I &$y)"),
+///     parameters(Span::new(b"($x = 42, I &$y)")),
 ///     Result::Done(
-///         &b""[..],
+///         Span::new_at(b"", 16, 1, 17),
 ///         Arity::Finite(vec![
 ///             Parameter {
 ///                 ty   : Ty::Copy(None),
-///                 name : Variable(&b"x"[..]),
-///                 value: Some(Expression::Literal(Literal::Integer(42i64)))
+///                 name : Variable(Span::new_at(b"x", 2, 1, 3)),
+///                 value: Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 6, 1, 7)))))
 ///             },
 ///             Parameter {
-///                 ty   : Ty::Reference(Some(Name::Unqualified(&b"I"[..]))),
-///                 name : Variable(&b"y"[..]),
+///                 ty   : Ty::Reference(Some(Name::Unqualified(Span::new_at(b"I", 10, 1, 11)))),
+///                 name : Variable(Span::new_at(b"y", 14, 1, 15)),
 ///                 value: None
 ///             }
 ///         ])
@@ -848,11 +1054,15 @@ pub enum Arity<'a> {
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Arity;
     /// use tagua_parser::rules::statements::function::parameters;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     parameters(b"()"),
-    ///     Result::Done(&b""[..], Arity::Constant)
+    ///     parameters(Span::new(b"()")),
+    ///     Result::Done(Span::new_at(b"", 2, 1, 3), Arity::Constant)
     /// );
     /// # }
     /// ```
@@ -872,21 +1082,25 @@ pub enum Arity<'a> {
     ///     Variable
     /// };
     /// use tagua_parser::rules::statements::function::parameters;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     parameters(b"($x, $y)"),
+    ///     parameters(Span::new(b"($x, $y)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 8, 1, 9),
     ///         Arity::Finite(vec![
     ///             Parameter {
     ///                 ty   : Ty::Copy(None),
-    ///                 name : Variable(&b"x"[..]),
+    ///                 name : Variable(Span::new_at(b"x", 2, 1, 3)),
     ///                 value: None
     ///             },
     ///             Parameter {
     ///                 ty   : Ty::Copy(None),
-    ///                 name : Variable(&b"y"[..]),
+    ///                 name : Variable(Span::new_at(b"y", 6, 1, 7)),
     ///                 value: None
     ///             }
     ///         ])
@@ -910,21 +1124,25 @@ pub enum Arity<'a> {
     ///     Variable
     /// };
     /// use tagua_parser::rules::statements::function::parameters;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     parameters(b"($x, ...$y)"),
+    ///     parameters(Span::new(b"($x, ...$y)")),
     ///     Result::Done(
-    ///         &b""[..],
+    ///         Span::new_at(b"", 11, 1, 12),
     ///         Arity::Infinite(vec![
     ///             Parameter {
     ///                 ty   : Ty::Copy(None),
-    ///                 name : Variable(&b"x"[..]),
+    ///                 name : Variable(Span::new_at(b"x", 2, 1, 3)),
     ///                 value: None
     ///             },
     ///             Parameter {
     ///                 ty   : Ty::Copy(None),
-    ///                 name : Variable(&b"y"[..]),
+    ///                 name : Variable(Span::new_at(b"y", 9, 1, 10)),
     ///                 value: None
     ///             }
     ///         ])
@@ -951,23 +1169,27 @@ pub enum Arity<'a> {
 ///     Variable
 /// };
 /// use tagua_parser::rules::statements::function::function;
+/// use tagua_parser::tokens::{
+///     Span,
+///     Token
+/// };
 ///
 /// # fn main() {
 /// assert_eq!(
-///     function(b"function f(I $x): O { return; }"),
+///     function(Span::new(b"function f(I $x): O { return; }")),
 ///     Result::Done(
-///         &b""[..],
+///         Span::new_at(b"", 31, 1, 32),
 ///         Statement::Function(
 ///             Function {
-///                 name  : &b"f"[..],
+///                 name  : Span::new_at(b"f", 9, 1, 10),
 ///                 inputs: Arity::Finite(vec![
 ///                     Parameter {
-///                         ty   : Ty::Copy(Some(Name::Unqualified(&b"I"[..]))),
-///                         name : Variable(&b"x"[..]),
+///                         ty   : Ty::Copy(Some(Name::Unqualified(Span::new_at(b"I", 11, 1, 12)))),
+///                         name : Variable(Span::new_at(b"x", 14, 1, 15)),
 ///                         value: None
 ///                     }
 ///                 ]),
-///                 output: Ty::Copy(Some(Name::Unqualified(&b"O"[..]))),
+///                 output: Ty::Copy(Some(Name::Unqualified(Span::new_at(b"O", 18, 1, 19)))),
 ///                 body  : vec![Statement::Return]
 ///             }
 ///         )
@@ -1013,30 +1235,34 @@ pub struct Function<'a> {
 ///     Variable
 /// };
 /// use tagua_parser::rules::expressions::primaries::anonymous_function;
+/// use tagua_parser::tokens::{
+///     Span,
+///     Token
+/// };
 ///
 /// # fn main() {
 /// assert_eq!(
-///     anonymous_function(b"static function &(I ...$x) use (&$y, $z): O { return; }"),
+///     anonymous_function(Span::new(b"static function &(I ...$x) use (&$y, $z): O { return; }")),
 ///     Result::Done(
-///         &b""[..],
+///         Span::new_at(b"", 55, 1, 56),
 ///         Expression::AnonymousFunction(
 ///             AnonymousFunction {
 ///                 declaration_scope: Scope::Static,
 ///                 inputs           : Arity::Infinite(vec![
 ///                     Parameter {
-///                         ty   : Ty::Copy(Some(Name::Unqualified(&b"I"[..]))),
-///                         name : Variable(&b"x"[..]),
+///                         ty   : Ty::Copy(Some(Name::Unqualified(Span::new_at(b"I", 18, 1, 19)))),
+///                         name : Variable(Span::new_at(b"x", 24, 1, 25)),
 ///                         value: None
 ///                     }
 ///                 ]),
-///                 output         : Ty::Reference(Some(Name::Unqualified(&b"O"[..]))),
+///                 output         : Ty::Reference(Some(Name::Unqualified(Span::new_at(b"O", 42, 1, 43)))),
 ///                 enclosing_scope: Some(vec![
 ///                     Expression::Reference(
 ///                         Box::new(
-///                             Expression::Variable(Variable(&b"y"[..]))
+///                             Expression::Variable(Variable(Span::new_at(b"y", 34, 1, 35)))
 ///                         )
 ///                     ),
-///                     Expression::Variable(Variable(&b"z"[..]))
+///                     Expression::Variable(Variable(Span::new_at(b"z", 38, 1, 39)))
 ///                 ]),
 ///                 body: vec![Statement::Return]
 ///             }

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -61,7 +61,7 @@ pub enum Literal {
     /// use tagua_parser::rules::literals::literal;
     ///
     /// # fn main() {
-    /// assert_eq!(literal(b"true"), Result::Done(&b""[..], Literal::Boolean(true)));
+    /// assert_eq!(literal(b"true"),  Result::Done(&b""[..], Literal::Boolean(true)));
     /// assert_eq!(literal(b"false"), Result::Done(&b""[..], Literal::Boolean(false)));
     /// # }
     /// ```

--- a/source/internal.rs
+++ b/source/internal.rs
@@ -47,7 +47,7 @@ pub use nom::Needed;
 pub type InputElement = u8;
 
 /// Represent the type of the input.
-pub type Input<'a>    = &'a [InputElement];
+pub type Input<'a> = &'a [InputElement];
 
 /// Fold an item into a vector.
 /// This is useful when combined with the `fold_many0!` macro for instance.

--- a/source/internal.rs
+++ b/source/internal.rs
@@ -31,10 +31,23 @@
 
 //! Internal utilities for the parser.
 
+/// Contain the error that a parser can return.
 pub use nom::Err as Error;
+
+/// Indicate which parser has returned an error.
 pub use nom::ErrorKind;
+
+/// Hold the result of a parser.
 pub use nom::IResult as Result;
+
+/// Contain information on needed data if a parser returned `Incomplete`.
 pub use nom::Needed;
+
+/// Represent the type of the input elements.
+pub type InputElement = u8;
+
+/// Represent the type of the input.
+pub type Input<'a>    = &'a [InputElement];
 
 /// Fold an item into a vector.
 /// This is useful when combined with the `fold_many0!` macro for instance.

--- a/source/internal.rs
+++ b/source/internal.rs
@@ -51,7 +51,7 @@ pub use nom::Needed;
 ///
 /// # fn main() {
 /// named!(
-///     test< &[u8], Vec<&[u8]> >,
+///     test<&[u8], Vec<&[u8]>>,
 ///     fold_many0!(
 ///         tag!("abc"),
 ///         Vec::new(),

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -85,10 +85,11 @@ pub use self::internal::*;
 /// # Examples
 ///
 /// ```
-/// use tagua_parser as parser;
+/// use tagua_parser::parse;
+/// use tagua_parser::tokens::Span;
 ///
-/// let expression = b"1+2";
-/// parser::parse(&expression[..]);
+/// let expression = Span::new(b"1+2");
+/// tagua_parser::parse(expression);
 /// ```
 pub fn parse(input: tokens::Span) -> ast::Expression {
     rules::root(input)

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -61,6 +61,8 @@ extern crate lazy_static;
 #[macro_use]
 extern crate nom;
 extern crate regex;
+extern crate memchr;
+extern crate bytecount;
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -90,6 +90,6 @@ pub use self::internal::*;
 /// let expression = b"1+2";
 /// parser::parse(&expression[..]);
 /// ```
-pub fn parse(input: &[u8]) -> ast::Expression {
+pub fn parse(input: tokens::Span) -> ast::Expression {
     rules::root(input)
 }

--- a/source/macros.rs
+++ b/source/macros.rs
@@ -279,7 +279,7 @@ macro_rules! keyword(
 ///
 /// # fn main() {
 /// named!(
-///     test< Vec<&[u8]> >,
+///     test<Vec<&[u8]>>,
 ///     fold_into_vector_many0!(
 ///         tag!("abc"),
 ///         Vec::new()
@@ -507,7 +507,7 @@ mod tests {
     #[test]
     fn case_fold_into_vector_many0() {
         named!(
-            test< Vec<&[u8]> >,
+            test<Vec<&[u8]>>,
             fold_into_vector_many0!(
                 tag!("abc"),
                 Vec::new()

--- a/source/rules/comments.rs
+++ b/source/rules/comments.rs
@@ -50,9 +50,16 @@ named_attr!(
         # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::rules::comments::comment;
+        use tagua_parser::tokens::Span;
 
         # fn main () {
-        assert_eq!(comment(b\"/* foo */ bar\"), Result::Done(&b\" bar\"[..], &b\" foo \"[..]));
+        assert_eq!(
+            comment(Span::new(b\"/* foo */ bar\")),
+            Result::Done(
+                Span::new_at(b\" bar\", 9, 1, 10),
+                Span::new_at(b\" foo \", 2, 1, 3)
+            )
+        );
         # }
         ```
     "],

--- a/source/rules/comments.rs
+++ b/source/rules/comments.rs
@@ -203,6 +203,15 @@ mod tests {
     }
 
     #[test]
+    fn case_comment_delimited_almost_nested() {
+        let input  = Span::new(b"/****/xyz");
+        let output = Result::Done(Span::new_at(b"xyz", 6, 1, 7), Span::new_at(b"**", 2, 1, 3));
+
+        assert_eq!(comment_delimited153(input), output);
+        assert_eq!(comment153(input), output);
+    }
+
+    #[test]
     fn case_comment_delimited() {
         let input  = Span::new(b"/* foo bar\nbaz\r\nqux // hello,\n /*world!*/xyz */");
         let output = Result::Done(Span::new_at(b"xyz */", 41, 4, 12), Span::new_at(b" foo bar\nbaz\r\nqux // hello,\n /*world!", 2, 1, 3));

--- a/source/rules/comments.rs
+++ b/source/rules/comments.rs
@@ -203,15 +203,6 @@ mod tests {
     }
 
     #[test]
-    fn case_comment_delimited_almost_nested() {
-        let input  = Span::new(b"/****/xyz");
-        let output = Result::Done(Span::new_at(b"xyz", 6, 1, 7), Span::new_at(b"**", 2, 1, 3));
-
-        assert_eq!(comment_delimited153(input), output);
-        assert_eq!(comment153(input), output);
-    }
-
-    #[test]
     fn case_comment_delimited() {
         let input  = Span::new(b"/* foo bar\nbaz\r\nqux // hello,\n /*world!*/xyz */");
         let output = Result::Done(Span::new_at(b"xyz */", 41, 4, 12), Span::new_at(b" foo bar\nbaz\r\nqux // hello,\n /*world!", 2, 1, 3));

--- a/source/rules/expressions/constant.rs
+++ b/source/rules/expressions/constant.rs
@@ -41,33 +41,20 @@ use super::super::super::ast::{
     Expression,
     Literal
 };
+use super::super::super::tokens::Span;
 
 named_attr!(
     #[doc="
         Recognize all kind of constant expressions.
     "],
-    pub constant_expression<Expression>,
+    pub constant_expression<Span, Expression>,
     alt!(
         literal => { literal_mapper }
       | array
     )
 );
 
-#[inline(always)]
-fn literal_mapper<'a>(literal: Literal) -> Expression<'a> {
+#[inline]
+fn literal_mapper(literal: Literal) -> Expression {
     Expression::Literal(literal)
 }
-
-
-/*
-#[cfg(test)]
-mod tests {
-    use super::constant;
-    use super::super::expression;
-    use super::super::super::super::ast::{
-        Expression,
-        Literal
-    };
-    use super::super::super::super::internal::Result;
-}
-*/

--- a/source/rules/expressions/mod.rs
+++ b/source/rules/expressions/mod.rs
@@ -52,14 +52,25 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::expression;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
         assert_eq!(
-            expression(b\"echo 'Hello, World!'\"),
+            expression(Span::new(b\"echo 'Hello, World!'\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 20, 1, 21),
                 Expression::Echo(vec![
-                    Expression::Literal(Literal::String(b\"Hello, World!\".to_vec()))
+                    Expression::Literal(
+                        Literal::String(
+                            Token::new(
+                                b\"Hello, World!\".to_vec(),
+                                Span::new_at(b\"'Hello, World!'\", 5, 1, 6)
+                            )
+                        )
+                    )
                 ])
             )
         );

--- a/source/rules/expressions/mod.rs
+++ b/source/rules/expressions/mod.rs
@@ -39,6 +39,7 @@ pub mod constant;
 pub mod primaries;
 
 use super::super::ast::Expression;
+use super::super::tokens::Span;
 
 named_attr!(
     #[doc="
@@ -65,6 +66,6 @@ named_attr!(
         # }
         ```
     "],
-    pub expression<Expression>,
+    pub expression<Span, Expression>,
     call!(primaries::primary)
 );

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -91,14 +91,25 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::primary;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            primary(b\"echo 'Hello, World!'\"),
+            primary(Span::new(b\"echo 'Hello, World!'\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 20, 1, 21),
                 Expression::Echo(vec![
-                    Expression::Literal(Literal::String(b\"Hello, World!\".to_vec()))
+                    Expression::Literal(
+                        Literal::String(
+                            Token::new(
+                                b\"Hello, World!\".to_vec(),
+                                Span::new_at(b\"'Hello, World!'\", 5, 1, 6)
+                            )
+                        )
+                    )
                 ])
             )
         );
@@ -149,20 +160,24 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal, Variable};
         use tagua_parser::rules::expressions::primaries::array;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            array(b\"[42, 'foo' => $bar]\"),
+            array(Span::new(b\"[42, 'foo' => $bar]\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 19, 1, 20),
                 Expression::Array(vec![
                     (
                         None,
-                        Expression::Literal(Literal::Integer(42i64))
+                        Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b\"42\", 1, 1, 2))))
                     ),
                     (
-                        Some(Expression::Literal(Literal::String(b\"foo\".to_vec()))),
-                        Expression::Variable(Variable(&b\"bar\"[..]))
+                        Some(Expression::Literal(Literal::String(Token::new(b\"foo\".to_vec(), Span::new_at(b\"'foo'\", 5, 1, 6))))),
+                        Expression::Variable(Variable(Span::new_at(b\"bar\", 15, 1, 16)))
                     )
                 ])
             )
@@ -271,14 +286,25 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic(b\"echo 'Hello, World!'\"),
+            intrinsic(Span::new(b\"echo 'Hello, World!'\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 20, 1, 21),
                 Expression::Echo(vec![
-                    Expression::Literal(Literal::String(b\"Hello, World!\".to_vec()))
+                    Expression::Literal(
+                        Literal::String(
+                            Token::new(
+                                b\"Hello, World!\".to_vec(),
+                                Span::new_at(b\"'Hello, World!'\", 5, 1, 6)
+                            )
+                        )
+                    )
                 ])
             )
         );
@@ -322,15 +348,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_echo;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic_echo(b\"echo 'Hello,', ' World!'\"),
+            intrinsic_echo(Span::new(b\"echo 'Hello,', ' World!'\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 24, 1, 25),
                 Expression::Echo(vec![
-                    Expression::Literal(Literal::String(b\"Hello,\".to_vec())),
-                    Expression::Literal(Literal::String(b\" World!\".to_vec()))
+                    Expression::Literal(Literal::String(Token::new(b\"Hello,\".to_vec(), Span::new_at(b\"'Hello,'\", 5, 1, 6)))),
+                    Expression::Literal(Literal::String(Token::new(b\" World!\".to_vec(), Span::new_at(b\"' World!'\", 15, 1, 16))))
                 ])
             )
         );
@@ -377,20 +407,24 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal, Variable};
         use tagua_parser::rules::expressions::primaries::intrinsic_list;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic_list(b\"list('foo' => $foo, 'bar' => $bar)\"),
+            intrinsic_list(Span::new(b\"list('foo' => $foo, 'bar' => $bar)\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 34, 1, 35),
                 Expression::List(vec![
                     Some((
-                        Some(Expression::Literal(Literal::String(b\"foo\".to_vec()))),
-                        Expression::Variable(Variable(&b\"foo\"[..]))
+                        Some(Expression::Literal(Literal::String(Token::new(b\"foo\".to_vec(), Span::new_at(b\"'foo'\", 5, 1, 6))))),
+                        Expression::Variable(Variable(Span::new_at(b\"foo\", 15, 1, 16)))
                     )),
                     Some((
-                        Some(Expression::Literal(Literal::String(b\"bar\".to_vec()))),
-                        Expression::Variable(Variable(&b\"bar\"[..]))
+                        Some(Expression::Literal(Literal::String(Token::new(b\"bar\".to_vec(), Span::new_at(b\"'bar'\", 20, 1, 21))))),
+                        Expression::Variable(Variable(Span::new_at(b\"bar\", 30, 1, 31)))
                     ))
                 ])
             )
@@ -506,15 +540,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Variable};
         use tagua_parser::rules::expressions::primaries::intrinsic_unset;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic_unset(b\"unset($foo, $bar)\"),
+            intrinsic_unset(Span::new(b\"unset($foo, $bar)\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 17, 1, 18),
                 Expression::Unset(vec![
-                    Expression::Variable(Variable(&b\"foo\"[..])),
-                    Expression::Variable(Variable(&b\"bar\"[..]))
+                    Expression::Variable(Variable(Span::new_at(b\"foo\", 7, 1, 8))),
+                    Expression::Variable(Variable(Span::new_at(b\"bar\", 13, 1, 14)))
                 ])
             )
         );
@@ -562,16 +600,22 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_empty;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic_empty(b\"empty('foo')\"),
+            intrinsic_empty(Span::new(b\"empty('foo')\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 12, 1, 13),
                 Expression::Empty(
                     Box::new(
                         Expression::Literal(
-                            Literal::String(b\"foo\".to_vec())
+                            Literal::String(
+                                Token::new(b\"foo\".to_vec(), Span::new_at(b\"'foo'\", 6, 1, 7))
+                            )
                         )
                     )
                 )
@@ -611,16 +655,20 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_eval;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic_eval(b\"eval('1 + 2')\"),
+            intrinsic_eval(Span::new(b\"eval('1 + 2')\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 13, 1, 14),
                 Expression::Eval(
                     Box::new(
                         Expression::Literal(
-                            Literal::String(b\"1 + 2\".to_vec())
+                            Literal::String(Token::new(b\"1 + 2\".to_vec(), Span::new_at(b\"'1 + 2'\", 5, 1, 6)))
                         )
                     )
                 )
@@ -660,17 +708,21 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_exit;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic_exit(b\"exit(7)\"),
+            intrinsic_exit(Span::new(b\"exit(7)\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 7, 1, 8),
                 Expression::Exit(
                     Some(
                         Box::new(
                             Expression::Literal(
-                                Literal::Integer(7i64)
+                                Literal::Integer(Token::new(7i64, Span::new_at(b\"7\", 5, 1, 6)))
                             )
                         )
                     )
@@ -732,15 +784,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Variable};
         use tagua_parser::rules::expressions::primaries::intrinsic_isset;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic_isset(b\"isset($foo, $bar)\"),
+            intrinsic_isset(Span::new(b\"isset($foo, $bar)\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 17, 1, 18),
                 Expression::Isset(vec![
-                    Expression::Variable(Variable(&b\"foo\"[..])),
-                    Expression::Variable(Variable(&b\"bar\"[..]))
+                    Expression::Variable(Variable(Span::new_at(b\"foo\", 7, 1, 8))),
+                    Expression::Variable(Variable(Span::new_at(b\"bar\", 13, 1, 14)))
                 ])
             )
         );
@@ -788,15 +844,23 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_print;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            intrinsic_print(b\"print('Hello, World!')\"),
+            intrinsic_print(Span::new(b\"print('Hello, World!')\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 22, 1, 23),
                 Expression::Print(
                     Box::new(
-                        Expression::Literal(Literal::String(b\"Hello, World!\".to_vec()))
+                        Expression::Literal(
+                            Literal::String(
+                                Token::new(b\"Hello, World!\".to_vec(), Span::new_at(b\"'Hello, World!'\", 6, 1, 7))
+                            )
+                        )
                     )
                 )
             )
@@ -839,38 +903,42 @@ named_attr!(
             Variable
         };
         use tagua_parser::rules::expressions::primaries::anonymous_function;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            anonymous_function(b\"function &($x, \\\\I\\\\J $y, int &$z) use ($a, &$b): O { return; }\"),
+            anonymous_function(Span::new(b\"function &($x, \\\\I\\\\J $y, int &$z) use ($a, &$b): O { return; }\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 61, 1, 62),
                 Expression::AnonymousFunction(
                     AnonymousFunction {
                         declaration_scope: Scope::Dynamic,
                         inputs           : Arity::Finite(vec![
                             Parameter {
                                 ty   : Ty::Copy(None),
-                                name : Variable(&b\"x\"[..]),
+                                name : Variable(Span::new_at(b\"x\", 12, 1, 13)),
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![&b\"I\"[..], &b\"J\"[..]]))),
-                                name : Variable(&b\"y\"[..]),
+                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b\"I\", 16, 1, 17), Span::new_at(b\"J\", 18, 1, 19)]))),
+                                name : Variable(Span::new_at(b\"y\", 21, 1, 22)),
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Reference(Some(Name::FullyQualified(vec![&b\"int\"[..]]))),
-                                name : Variable(&b\"z\"[..]),
+                                ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b\"int\", 24, 1, 25)]))),
+                                name : Variable(Span::new_at(b\"z\", 30, 1, 31)),
                                 value: None
                             }
                         ]),
-                        output         : Ty::Reference(Some(Name::Unqualified(&b\"O\"[..]))),
+                        output         : Ty::Reference(Some(Name::Unqualified(Span::new_at(b\"O\", 48, 1, 49)))),
                         enclosing_scope: Some(vec![
-                            Expression::Variable(Variable(&b\"a\"[..])),
+                            Expression::Variable(Variable(Span::new_at(b\"a\", 39, 1, 40))),
                             Expression::Reference(
                                 Box::new(
-                                    Expression::Variable(Variable(&b\"b\"[..]))
+                                    Expression::Variable(Variable(Span::new_at(b\"b\", 44, 1, 45)))
                                 )
                             )
                         ]),

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -451,7 +451,7 @@ named!(
 );
 
 named!(
-    intrinsic_keyed_list_item< Option<(Option<Expression>, Expression)> >,
+    intrinsic_keyed_list_item<Option<(Option<Expression>, Expression)>>,
     do_parse!(
         key: terminated!(
             expression,
@@ -917,7 +917,7 @@ named_attr!(
 );
 
 named!(
-    anonymous_function_use< Vec<Expression> >,
+    anonymous_function_use<Vec<Expression>>,
     map_res!(
         terminated!(
             preceded!(
@@ -947,7 +947,7 @@ fn anonymous_function_use_mapper<'a>(enclosing_list: Option<Vec<Expression<'a>>>
 }
 
 named!(
-    anonymous_function_use_list< Vec<Expression> >,
+    anonymous_function_use_list<Vec<Expression>>,
     do_parse!(
         accumulator: map_res!(
             anonymous_function_use_list_item,

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -71,9 +71,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::literal;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(literal(b\"0x2a\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        assert_eq!(
+            literal(Span::new(b\"0x2a\")),
+            Result::Done(
+                Span::new_at(b\"\", 4, 1, 5),
+                Literal::Integer(Token::new(42i64, Span::new(b\"0x2a\")))
+            )
+        );
         # }
         ```
     "],
@@ -98,9 +108,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::null;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(null(b\"null\"), Result::Done(&b\"\"[..], Literal::Null));
+        assert_eq!(
+            null(Span::new(b\"null\")),
+            Result::Done(
+                Span::new_at(b\"\", 4, 1, 5),
+                Literal::Null(Token::new((), Span::new(b\"null\")))
+            )
+        );
         # }
         ```
     "],
@@ -127,9 +147,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::boolean;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(boolean(b\"true\"), Result::Done(&b\"\"[..], Literal::Boolean(true)));
+        assert_eq!(
+            boolean(Span::new(b\"true\")),
+            Result::Done(
+                Span::new_at(b\"\", 4, 1, 5),
+                Literal::Boolean(Token::new(true, Span::new(b\"true\")))
+            )
+        );
         # }
         ```
     "],
@@ -158,9 +188,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::integer;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(integer(b\"0b101010\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        assert_eq!(
+            integer(Span::new(b\"0b101010\")),
+            Result::Done(
+                Span::new_at(b\"\", 8, 1, 9),
+                Literal::Integer(Token::new(42i64, Span::new(b\"0b101010\")))
+            )
+        );
         # }
         ```
     "],
@@ -184,9 +224,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::binary;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(binary(b\"0b101010\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        assert_eq!(
+            binary(Span::new(b\"0b101010\")),
+            Result::Done(
+                Span::new_at(b\"\", 8, 1, 9),
+                Literal::Integer(Token::new(42i64, Span::new(b\"0b101010\")))
+            )
+        );
         # }
         ```
     "],
@@ -222,9 +272,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::octal;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(octal(b\"052\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        assert_eq!(
+            octal(Span::new(b\"052\")),
+            Result::Done(
+                Span::new_at(b\"\", 3, 1, 4),
+                Literal::Integer(Token::new(42i64, Span::new(b\"052\")))
+            )
+        );
         # }
         ```
     "],
@@ -266,9 +326,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::decimal;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(decimal(b\"42\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        assert_eq!(
+            decimal(Span::new(b\"42\")),
+            Result::Done(
+                Span::new_at(b\"\", 2, 1, 3),
+                Literal::Integer(Token::new(42i64, Span::new(b\"42\")))
+            )
+        );
         # }
         ```
     "],
@@ -314,9 +384,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::decimal;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(decimal(b\"42\"), Result::Done(&b\"\"[..], Literal::Integer(42i64)));
+        assert_eq!(
+            decimal(Span::new(b\"42\")),
+            Result::Done(
+                Span::new_at(b\"\", 2, 1, 3),
+                Literal::Integer(Token::new(42i64, Span::new(b\"42\")))
+            )
+        );
         # }
         ```
     "],
@@ -352,9 +432,19 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::exponential;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
-        assert_eq!(exponential(b\"123.456e+78\"), Result::Done(&b\"\"[..], Literal::Real(123.456e78f64)));
+        assert_eq!(
+            exponential(Span::new(b\"123.456e+78\")),
+            Result::Done(
+                Span::new_at(b\"\", 11, 1, 12),
+                Literal::Real(Token::new(123.456e78f64, Span::new(b\"123.456e+78\")))
+            )
+        );
         # }
         ```
     "],
@@ -405,11 +495,18 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::string;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main () {
         assert_eq!(
-            string(b\"'foobar'\"),
-            Result::Done(&b\"\"[..], Literal::String(b\"foobar\".to_vec()))
+            string(Span::new(b\"'foobar'\")),
+            Result::Done(
+                Span::new_at(b\"\", 8, 1, 9),
+                Literal::String(Token::new(b\"foobar\".to_vec(), Span::new(b\"'foobar'\")))
+            )
         );
         # }
         ```

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -36,14 +36,21 @@
 //! section](https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#literals).
 
 use nom::{
-    hex_digit,
-    oct_digit
+    InputLength,
+    Slice
 };
-use std::num::ParseIntError;
+use std::num::{
+    ParseFloatError,
+    ParseIntError
+};
 use std::result::Result as StdResult;
 use std::str::FromStr;
 use std::str;
 use super::super::ast::Literal;
+use super::super::tokens::{
+    Span,
+    Token
+};
 use super::super::internal::{
     Error,
     ErrorKind,
@@ -70,7 +77,7 @@ named_attr!(
         # }
         ```
     "],
-    pub literal<Literal>,
+    pub literal<Span, Literal>,
     alt!(
         null
       | boolean
@@ -97,14 +104,17 @@ named_attr!(
         # }
         ```
     "],
-    pub null<Literal>,
+    pub null<Span, Literal>,
     map_res!(
-        itag!("null"),
-        |_| -> StdResult<Literal, ()> {
-            Ok(Literal::Null)
-        }
+        itag!(b"null"),
+        null_mapper
     )
 );
+
+#[inline]
+fn null_mapper(span: Span) -> StdResult<Literal, ()> {
+    Ok(Literal::Null(Token::new((), span)))
+}
 
 named_attr!(
     #[doc="
@@ -123,14 +133,17 @@ named_attr!(
         # }
         ```
     "],
-    pub boolean<Literal>,
+    pub boolean<Span, Literal>,
     map_res!(
-        alt!(itag!(&b"true"[..]) | itag!(&b"false"[..])),
-        |bytes: &[u8]| -> StdResult<Literal, ()> {
-            Ok(Literal::Boolean(bytes[0] == 't' as u8))
-        }
+        alt!(itag!(b"true") | itag!(b"false")),
+        boolean_mapper
     )
 );
+
+#[inline]
+fn boolean_mapper(span: Span) -> StdResult<Literal, ()> {
+    Ok(Literal::Boolean(Token::new(span.as_slice()[0] == b't', span)))
+}
 
 named_attr!(
     #[doc="
@@ -151,7 +164,7 @@ named_attr!(
         # }
         ```
     "],
-    pub integer<Literal>,
+    pub integer<Span, Literal>,
     alt_complete!(
         binary
       | decimal
@@ -177,29 +190,26 @@ named_attr!(
         # }
         ```
     "],
-    pub binary<Literal>,
+    pub binary<Span, Literal>,
     map_res!(
-        preceded!(
-            tag!("0"),
-            preceded!(
-                is_a!("bB"),
-                is_a!("01")
-            )
-        ),
-        |bytes: &[u8]| {
-            i64
-                ::from_str_radix(
-                    unsafe { str::from_utf8_unchecked(bytes) },
-                    2
-                )
-                .and_then(
-                    |binary| {
-                        Ok(Literal::Integer(binary))
-                    }
-                )
-        }
+        regex!(r"(?-u)^0[bB][01]+"),
+        binary_mapper
     )
 );
+
+#[inline]
+fn binary_mapper(span: Span) -> StdResult<Literal, ParseIntError> {
+    i64
+        ::from_str_radix(
+            unsafe { str::from_utf8_unchecked(&(span.as_slice())[2..]) },
+            2
+        )
+        .and_then(
+            |binary| {
+                Ok(Literal::Integer(Token::new(binary, span)))
+            }
+        )
+}
 
 named_attr!(
     #[doc="
@@ -218,29 +228,30 @@ named_attr!(
         # }
         ```
     "],
-    pub octal<Literal>,
+    pub octal<Span, Literal>,
     map_res!(
-        preceded!(tag!("0"), opt!(complete!(oct_digit))),
-        |value: Option<&[u8]>| {
-            match value {
-                Some(bytes) =>
-                    i64
-                        ::from_str_radix(
-                            unsafe { str::from_utf8_unchecked(bytes) },
-                            8
-                        )
-                        .and_then(
-                            |octal| {
-                                Ok(Literal::Integer(octal))
-                            }
-                        ),
-
-                None =>
-                    Ok(Literal::Integer(0i64))
-            }
-        }
+        regex!(r"(?-u)^0[0-7]*"),
+        octal_mapper
     )
 );
+
+#[inline]
+fn octal_mapper(span: Span) -> StdResult<Literal, ParseIntError> {
+    if span.input_len() > 1 {
+        i64
+            ::from_str_radix(
+                unsafe { str::from_utf8_unchecked(span.as_slice()) },
+                8
+            )
+            .and_then(
+                |octal| {
+                    Ok(Literal::Integer(Token::new(octal, span)))
+                }
+            )
+    } else {
+        Ok(Literal::Integer(Token::new(0i64, span)))
+    }
+}
 
 named_attr!(
     #[doc="
@@ -261,33 +272,36 @@ named_attr!(
         # }
         ```
     "],
-    pub decimal<Literal>,
+    pub decimal<Span, Literal>,
     map_res!(
-        re_bytes_find_static!(r"(?-u)^[1-9][0-9]*"),
-        |bytes: &[u8]| {
-            let string = unsafe { str::from_utf8_unchecked(bytes) };
-
-            i64
-                ::from_str(string)
-                .and_then(
-                    |decimal| {
-                        Ok(Literal::Integer(decimal))
-                   }
-                )
-                .or_else(
-                    |_: ParseIntError| {
-                        f64
-                            ::from_str(string)
-                            .and_then(
-                                |decimal| {
-                                    Ok(Literal::Real(decimal))
-                                }
-                            )
-                    }
-                )
-        }
+        regex!(r"(?-u)^[1-9][0-9]*"),
+        decimal_mapper
     )
 );
+
+#[inline]
+fn decimal_mapper(span: Span) -> StdResult<Literal, ParseFloatError> {
+    let string = unsafe { str::from_utf8_unchecked(span.as_slice()) };
+
+    i64
+        ::from_str(string)
+        .and_then(
+            |decimal| {
+                Ok(Literal::Integer(Token::new(decimal, span)))
+            }
+        )
+        .or_else(
+            |_: ParseIntError| {
+                f64
+                    ::from_str(string)
+                    .and_then(
+                        |decimal| {
+                            Ok(Literal::Real(Token::new(decimal, span)))
+                        }
+                    )
+            }
+        )
+}
 
 named_attr!(
     #[doc="
@@ -306,29 +320,26 @@ named_attr!(
         # }
         ```
     "],
-    pub hexadecimal<Literal>,
+    pub hexadecimal<Span, Literal>,
     map_res!(
-        preceded!(
-            tag!("0"),
-            preceded!(
-                is_a!("xX"),
-                complete!(hex_digit)
-            )
-        ),
-        |bytes: &[u8]| {
-            i64
-                ::from_str_radix(
-                    unsafe { str::from_utf8_unchecked(bytes) },
-                    16
-                )
-                .and_then(
-                    |hexadecimal| {
-                        Ok(Literal::Integer(hexadecimal))
-                    }
-                )
-        }
+        regex!(r"(?-u)^0[xX][0-9a-fA-F]+"),
+        hexadecimal_mapper
     )
 );
+
+#[inline]
+fn hexadecimal_mapper(span: Span) -> StdResult<Literal, ParseIntError> {
+    i64
+        ::from_str_radix(
+            unsafe { str::from_utf8_unchecked(&(span.as_slice())[2..]) },
+            16
+        )
+        .and_then(
+            |hexadecimal| {
+                Ok(Literal::Integer(Token::new(hexadecimal, span)))
+            }
+        )
+}
 
 named_attr!(
     #[doc="
@@ -347,20 +358,23 @@ named_attr!(
         # }
         ```
     "],
-    pub exponential<Literal>,
+    pub exponential<Span, Literal>,
     map_res!(
-        re_bytes_find_static!(r"(?-u)^(([0-9]*\.[0-9]+|[0-9]+\.)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)"),
-        |bytes: &[u8]| {
-            f64
-                ::from_str(unsafe { str::from_utf8_unchecked(bytes) })
-                .and_then(
-                    |exponential| {
-                        Ok(Literal::Real(exponential))
-                    }
-                )
-        }
+        regex!(r"(?-u)^(([0-9]*\.[0-9]+|[0-9]+\.)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)"),
+        exponential_mapper
     )
 );
+
+#[inline]
+fn exponential_mapper(span: Span) -> StdResult<Literal, ParseFloatError> {
+    f64
+        ::from_str(unsafe { str::from_utf8_unchecked(span.as_slice()) })
+        .and_then(
+            |exponential| {
+                Ok(Literal::Real(Token::new(exponential, span)))
+            }
+        )
+}
 
 /// String errors.
 pub enum StringError {
@@ -400,29 +414,30 @@ named_attr!(
         # }
         ```
     "],
-    pub string<Literal>,
+    pub string<Span, Literal>,
     alt!(
         string_single_quoted
       | string_nowdoc
     )
 );
 
-fn string_single_quoted(input: &[u8]) -> Result<&[u8], Literal> {
-    let input_length = input.len();
+fn string_single_quoted(span: Span) -> Result<Span, Literal> {
+    let input        = span.as_slice();
+    let input_length = span.input_len();
 
     if input_length < 2 {
         return Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32)));
     }
 
-    if input[0] == 'b' as u8 || input[0] == 'B' as u8 {
+    if input[0] == b'b' || input[0] == b'B' {
         if input_length < 3 {
             return Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32)));
-        } else if input[1] != '\'' as u8 {
+        } else if input[1] != b'\'' {
             return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32)));
         } else {
-            return string_single_quoted(&input[1..]);
+            return string_single_quoted(span.slice(1..));
         }
-    } else if input[0] != '\'' as u8 {
+    } else if input[0] != b'\'' {
         return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32)));
     }
 
@@ -431,91 +446,97 @@ fn string_single_quoted(input: &[u8]) -> Result<&[u8], Literal> {
     let mut iterator = input[offset..].iter().enumerate();
 
     while let Some((index, item)) = iterator.next() {
-        if *item == '\\' as u8 {
+        if *item == b'\\' {
             if let Some((next_index, next_item)) = iterator.next() {
-                if *next_item == '\'' as u8 ||
-                   *next_item == '\\' as u8 {
+                if *next_item == b'\'' ||
+                   *next_item == b'\\' {
                     output.extend(&input[offset..index + 1]);
                     offset = next_index + 1;
                 }
             } else {
                 return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32)));
             }
-        } else if *item == '\'' as u8 {
+        } else if *item == b'\'' {
             output.extend(&input[offset..index + 1]);
 
-            return Result::Done(&input[index + 2..], Literal::String(output));
+            return Result::Done(
+                span.slice(index + 2..),
+                Literal::String(Token::new(output, span))
+            );
         }
     }
 
     Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32)))
 }
 
-const STRING_NOWDOC_OPENING: &'static [u8] = &['<' as u8, '<' as u8, '<' as u8];
+const STRING_NOWDOC_OPENING: &'static [u8] = &[b'<', b'<', b'<'];
 
-fn string_nowdoc(input: &[u8]) -> Result<&[u8], Literal> {
-    let input_length = input.len();
+fn string_nowdoc(span: Span) -> Result<Span, Literal> {
+    let input        = span.as_slice();
+    let input_length = span.input_len();
 
     // `<<<'A'\nA\n` is the shortest datum.
     if input_length < 9 {
         return Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32)));
     }
 
-    if input[0] == 'b' as u8 || input[0] == 'B' as u8 {
+    if input[0] == b'b' || input[0] == b'B' {
         if input_length < 10 {
             return Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32)));
-        } else if false == input[1..].starts_with(STRING_NOWDOC_OPENING) {
+        } else if !input[1..].starts_with(STRING_NOWDOC_OPENING) {
             return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32)));
         } else {
-            return string_nowdoc(&input[1..]);
+            return string_nowdoc(span.slice(1..));
         }
-    } else if false == input.starts_with(STRING_NOWDOC_OPENING) {
+    } else if !input.starts_with(STRING_NOWDOC_OPENING) {
         return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32)));
     }
 
     let mut offset = 3;
 
     for item in input[offset..].iter() {
-        if *item != ' ' as u8 && *item != '\t' as u8 {
+        if *item != b' ' && *item != b'\t' {
             break;
         }
 
         offset += 1;
     }
 
-    if input[offset] != '\'' as u8 {
+    if input[offset] != b'\'' {
         return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32)));
     }
 
     offset += 1;
 
-    let name;
-    let next_input;
+    let name_span;
+    let next_span;
 
-    if let Result::Done(i, n) = tokens::name(&input[offset..]) {
-        name       = n;
-        next_input = i;
+    if let Result::Done(i, n) = tokens::name(span.slice(offset..)) {
+        name_span = n;
+        next_span = i;
     } else {
         return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidDelimiterIdentifier as u32)))
     }
 
-    let next_input_length = next_input.len();
-    let name_length       = name.len();
+    let name              = name_span.as_slice();
+    let name_length       = name_span.input_len();
+    let next_input        = next_span.as_slice();
+    let next_input_length = next_span.input_len();
 
-    if next_input_length < 3 + name_length || next_input[0] != '\'' as u8 || next_input[1] != '\n' as u8 {
-        if next_input[1] != '\r' as u8 || next_input[2] != '\n' as u8 {
+    if next_input_length < 3 + name_length || next_input[0] != b'\'' || next_input[1] != b'\n' {
+        if next_input[1] != b'\r' || next_input[2] != b'\n' {
             return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32)));
         }
     }
 
-    if next_input[1] == '\r' as u8 {
+    if next_input[1] == b'\r' {
         offset = 2;
     } else {
         offset = 1;
     }
 
     for (index, item) in next_input[offset..].iter().enumerate() {
-        if *item == '\n' as u8 {
+        if *item == b'\n' {
             if !next_input[offset + index + 1..].starts_with(name) {
                 continue;
             }
@@ -526,7 +547,7 @@ fn string_nowdoc(input: &[u8]) -> Result<&[u8], Literal> {
                 return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32)));
             }
 
-            if next_input[lookahead_offset] == ';' as u8 {
+            if next_input[lookahead_offset] == b';' {
                 lookahead_offset += 1;
             }
 
@@ -536,7 +557,7 @@ fn string_nowdoc(input: &[u8]) -> Result<&[u8], Literal> {
 
             let mut ending_offset = 0;
 
-            if next_input[lookahead_offset] == '\r' as u8 {
+            if next_input[lookahead_offset] == b'\r' {
                 if lookahead_offset + 1 >= next_input_length {
                     return Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32)));
                 }
@@ -545,17 +566,22 @@ fn string_nowdoc(input: &[u8]) -> Result<&[u8], Literal> {
                 lookahead_offset += 1;
             }
 
-            if next_input[lookahead_offset] == '\n' as u8 {
+            if next_input[lookahead_offset] == b'\n' {
                 if index == 0 {
                     return Result::Done(
-                        &next_input[lookahead_offset + 1..],
-                        Literal::String(Vec::new())
+                        next_span.slice(lookahead_offset + 1..),
+                        Literal::String(Token::new(Vec::new(), span))
                     );
                 }
 
                 return Result::Done(
-                    &next_input[lookahead_offset + 1..],
-                    Literal::String(next_input[offset + 1..offset - ending_offset + index].to_vec())
+                    next_span.slice(lookahead_offset + 1..),
+                    Literal::String(
+                        Token::new(
+                            next_input[offset + 1..offset - ending_offset + index].to_vec(),
+                            span
+                        )
+                    )
                 );
             }
         }
@@ -567,6 +593,7 @@ fn string_nowdoc(input: &[u8]) -> Result<&[u8], Literal> {
 
 #[cfg(test)]
 mod tests {
+    use nom::Slice;
     use super::{
         StringError,
         binary,
@@ -588,11 +615,18 @@ mod tests {
         ErrorKind,
         Result
     };
+    use super::super::super::tokens::{
+        Span,
+        Token
+    };
 
     #[test]
     fn case_null() {
-        let input  = b"null";
-        let output = Result::Done(&b""[..], Literal::Null);
+        let input  = Span::new(b"null");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Null(Token::new((), input))
+        );
 
         assert_eq!(null(input), output);
         assert_eq!(literal(input), output);
@@ -600,8 +634,11 @@ mod tests {
 
     #[test]
     fn case_null_case_insensitive() {
-        let input  = b"NuLl";
-        let output = Result::Done(&b""[..], Literal::Null);
+        let input  = Span::new(b"NuLl");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Null(Token::new((), Span::new(b"null")))
+        );
 
         assert_eq!(null(input), output);
         assert_eq!(literal(input), output);
@@ -609,8 +646,11 @@ mod tests {
 
     #[test]
     fn case_boolean_true() {
-        let input  = b"true";
-        let output = Result::Done(&b""[..], Literal::Boolean(true));
+        let input  = Span::new(b"true");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Boolean(Token::new(true, input))
+        );
 
         assert_eq!(boolean(input), output);
         assert_eq!(literal(input), output);
@@ -618,8 +658,11 @@ mod tests {
 
     #[test]
     fn case_boolean_true_case_insensitive() {
-        let input  = b"TrUe";
-        let output = Result::Done(&b""[..], Literal::Boolean(true));
+        let input  = Span::new(b"TrUe");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Boolean(Token::new(true, Span::new(b"true")))
+        );
 
         assert_eq!(boolean(input), output);
         assert_eq!(literal(input), output);
@@ -627,8 +670,11 @@ mod tests {
 
     #[test]
     fn case_boolean_false() {
-        let input  = b"false";
-        let output = Result::Done(&b""[..], Literal::Boolean(false));
+        let input  = Span::new(b"false");
+        let output = Result::Done(
+            Span::new_at(b"", 5, 1, 6),
+            Literal::Boolean(Token::new(false, input))
+        );
 
         assert_eq!(boolean(input), output);
         assert_eq!(literal(input), output);
@@ -636,8 +682,11 @@ mod tests {
 
     #[test]
     fn case_boolean_false_case_insensitive() {
-        let input  = b"FaLsE";
-        let output = Result::Done(&b""[..], Literal::Boolean(false));
+        let input  = Span::new(b"FaLsE");
+        let output = Result::Done(
+            Span::new_at(b"", 5, 1, 6),
+            Literal::Boolean(Token::new(false, Span::new(b"false")))
+        );
 
         assert_eq!(boolean(input), output);
         assert_eq!(literal(input), output);
@@ -645,18 +694,24 @@ mod tests {
 
     #[test]
     fn case_binary_lowercase_b() {
-        let input  = b"0b101010";
-        let output = Result::Done(&b""[..], Literal::Integer(42i64));
+        let input  = Span::new(b"0b101010");
+        let output = Result::Done(
+            Span::new_at(b"", 8, 1, 9),
+            Literal::Integer(Token::new(42i64, input))
+        );
 
-        assert_eq!(binary(input), output);
+        assert_eq!(binary(input),  output);
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_binary_uppercase_b() {
-        let input  = b"0B101010";
-        let output = Result::Done(&b""[..], Literal::Integer(42i64));
+        let input  = Span::new(b"0B101010");
+        let output = Result::Done(
+            Span::new_at(b"", 8, 1, 9),
+            Literal::Integer(Token::new(42i64, input))
+        );
 
         assert_eq!(binary(input), output);
         assert_eq!(integer(input), output);
@@ -665,8 +720,11 @@ mod tests {
 
     #[test]
     fn case_binary_maximum_integer_value() {
-        let input  = b"0b111111111111111111111111111111111111111111111111111111111111111";
-        let output = Result::Done(&b""[..], Literal::Integer(::std::i64::MAX));
+        let input  = Span::new(b"0b111111111111111111111111111111111111111111111111111111111111111");
+        let output = Result::Done(
+            Span::new_at(b"", 65, 1, 66),
+            Literal::Integer(Token::new(::std::i64::MAX, input))
+        );
 
         assert_eq!(binary(input), output);
         assert_eq!(integer(input), output);
@@ -675,48 +733,63 @@ mod tests {
 
     #[test]
     fn case_invalid_binary_overflow() {
-        let input  = b"0b1000000000000000000000000000000000000000000000000000000000000000";
-        let output = Result::Done(&b"b1000000000000000000000000000000000000000000000000000000000000000"[..], Literal::Integer(0i64));
+        let input  = Span::new(b"0b1000000000000000000000000000000000000000000000000000000000000000");
+        let output = Result::Done(
+            Span::new_at(b"b1000000000000000000000000000000000000000000000000000000000000000", 1, 1, 2),
+            Literal::Integer(Token::new(0i64, Span::new(b"0")))
+        );
 
-        assert_eq!(binary(input), Result::Error(Error::Position(ErrorKind::MapRes, &input[..])));
+        assert_eq!(binary(input), Result::Error(Error::Position(ErrorKind::MapRes, input)));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_invalid_binary_no_number() {
-        let input  = b"0b";
-        let output = Result::Done(&b"b"[..], Literal::Integer(0i64));
+        let input  = Span::new(b"0b");
+        let output = Result::Done(
+            Span::new_at(b"b", 1, 1, 2),
+            Literal::Integer(Token::new(0i64, Span::new(b"0")))
+        );
 
-        assert_eq!(binary(input), Result::Error(Error::Position(ErrorKind::MapRes, &b"0b"[..])));
+        assert_eq!(binary(input), Result::Error(Error::Code(ErrorKind::RegexpFind)));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_invalid_binary_not_starting_by_zero_b() {
-        let input  = b"1";
-        let output = Result::Done(&b""[..], Literal::Integer(1i64));
+        let input  = Span::new(b"1");
+        let output = Result::Done(
+            Span::new_at(b"", 1, 1, 2),
+            Literal::Integer(Token::new(1i64, input))
+        );
 
-        assert_eq!(binary(input), Result::Error(Error::Position(ErrorKind::Tag, &b"1"[..])));
+        assert_eq!(binary(input), Result::Error(Error::Code(ErrorKind::RegexpFind)));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_invalid_binary_not_in_base() {
-        let input  = b"0b120";
-        let output = Result::Done(&b"20"[..], Literal::Integer(1i64));
+        let input  = Span::new(b"0b120");
+        let output = Result::Done(
+            Span::new_at(b"20", 3, 1, 4),
+            Literal::Integer(Token::new(1i64, Span::new(b"0b1")))
+        );
 
-        assert_eq!(binary(input), output);
+        assert_eq!(binary(input),  output);
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_octal() {
-        let input  = b"052";
-        let output = Result::Done(&b""[..], Literal::Integer(42i64));
+        let input  = Span::new(b"052");
+        let output = Result::Done(
+            Span::new_at(b"", 3, 1, 4),
+            Literal::Integer(Token::new(42i64, input))
+        );
 
         assert_eq!(octal(input), output);
         assert_eq!(integer(input), output);
@@ -725,8 +798,11 @@ mod tests {
 
     #[test]
     fn case_octal_zero() {
-        let input  = b"0";
-        let output = Result::Done(&b""[..], Literal::Integer(0i64));
+        let input  = Span::new(b"0");
+        let output = Result::Done(
+            Span::new_at(b"", 1, 1, 2),
+            Literal::Integer(Token::new(0i64, input))
+        );
 
         assert_eq!(octal(input), output);
         assert_eq!(integer(input), output);
@@ -735,8 +811,11 @@ mod tests {
 
     #[test]
     fn case_octal_maximum_integer_value() {
-        let input  = b"0777777777777777777777";
-        let output = Result::Done(&b""[..], Literal::Integer(::std::i64::MAX));
+        let input  = Span::new(b"0777777777777777777777");
+        let output = Result::Done(
+            Span::new_at(b"", 22, 1, 23),
+            Literal::Integer(Token::new(::std::i64::MAX, input))
+        );
 
         assert_eq!(octal(input), output);
         assert_eq!(integer(input), output);
@@ -745,38 +824,47 @@ mod tests {
 
     #[test]
     fn case_invalid_octal_overflow() {
-        let input  = b"01000000000000000000000";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &b"01000000000000000000000"[..]));
+        let input  = Span::new(b"01000000000000000000000");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
-        assert_eq!(octal(input), Result::Error(Error::Position(ErrorKind::MapRes, &b"01000000000000000000000"[..])));
+        assert_eq!(octal(input), Result::Error(Error::Position(ErrorKind::MapRes, input)));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_invalid_octal_not_starting_by_zero() {
-        let input  = b"7";
-        let output = Result::Done(&b""[..], Literal::Integer(7i64));
+        let input  = Span::new(b"7");
+        let output = Result::Done(
+            Span::new_at(b"", 1, 1, 2),
+            Literal::Integer(Token::new(7i64, input))
+        );
 
-        assert_eq!(octal(input), Result::Error(Error::Position(ErrorKind::Tag, &b"7"[..])));
+        assert_eq!(octal(input), Result::Error(Error::Code(ErrorKind::RegexpFind)));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_invalid_octal_not_in_base() {
-        let input  = b"8";
-        let output = Result::Done(&b""[..], Literal::Integer(8));
+        let input  = Span::new(b"8");
+        let output = Result::Done(
+            Span::new_at(b"", 1, 1, 2),
+            Literal::Integer(Token::new(8i64, input))
+        );
 
-        assert_eq!(octal(input), Result::Error(Error::Position(ErrorKind::Tag, &b"8"[..])));
+        assert_eq!(octal(input), Result::Error(Error::Code(ErrorKind::RegexpFind)));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_decimal_one_digit() {
-        let input  = b"7";
-        let output = Result::Done(&b""[..], Literal::Integer(7i64));
+        let input  = Span::new(b"7");
+        let output = Result::Done(
+            Span::new_at(b"", 1, 1, 2),
+            Literal::Integer(Token::new(7i64, input))
+        );
 
         assert_eq!(decimal(input), output);
         assert_eq!(integer(input), output);
@@ -785,8 +873,11 @@ mod tests {
 
     #[test]
     fn case_decimal_many_digits() {
-        let input  = b"42";
-        let output = Result::Done(&b""[..], Literal::Integer(42i64));
+        let input  = Span::new(b"42");
+        let output = Result::Done(
+            Span::new_at(b"", 2, 1, 3),
+            Literal::Integer(Token::new(42i64, input))
+        );
 
         assert_eq!(decimal(input), output);
         assert_eq!(integer(input), output);
@@ -797,10 +888,9 @@ mod tests {
         fn case_decimal_random(input: u32) -> bool {
             let input  = input * 2 + 1;
             let string = input.to_string();
-            let bytes  = string.as_bytes();
 
-            match decimal(bytes) {
-                Result::Done(_, Literal::Integer(output)) => {
+            match decimal(Span::new(string.as_bytes())) {
+                Result::Done(_, Literal::Integer(Token { value: output, .. })) => {
                     input == output as u32
                 },
 
@@ -813,8 +903,11 @@ mod tests {
 
     #[test]
     fn case_decimal_plus() {
-        let input  = b"42+";
-        let output = Result::Done(&b"+"[..], Literal::Integer(42i64));
+        let input  = Span::new(b"42+");
+        let output = Result::Done(
+            Span::new_at(b"+", 2, 1, 3),
+            Literal::Integer(Token::new(42i64, Span::new(b"42")))
+        );
 
         assert_eq!(decimal(input), output);
         assert_eq!(integer(input), output);
@@ -823,8 +916,11 @@ mod tests {
 
     #[test]
     fn case_decimal_maximum_integer_value() {
-        let input  = b"9223372036854775807";
-        let output = Result::Done(&b""[..], Literal::Integer(::std::i64::MAX));
+        let input  = Span::new(b"9223372036854775807");
+        let output = Result::Done(
+            Span::new_at(b"", 19, 1, 20),
+            Literal::Integer(Token::new(::std::i64::MAX, input))
+        );
 
         assert_eq!(decimal(input), output);
         assert_eq!(integer(input), output);
@@ -833,8 +929,11 @@ mod tests {
 
     #[test]
     fn case_decimal_overflow_to_real() {
-        let input  = b"9223372036854775808";
-        let output = Result::Done(&b""[..], Literal::Real(9223372036854775808f64));
+        let input  = Span::new(b"9223372036854775808");
+        let output = Result::Done(
+            Span::new_at(b"", 19, 1, 20),
+            Literal::Real(Token::new(9223372036854775808f64, input))
+        );
 
         assert_eq!(decimal(input), output);
         assert_eq!(integer(input), output);
@@ -843,8 +942,11 @@ mod tests {
 
     #[test]
     fn case_decimal_maximum_real_value() {
-        let input  = b"179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-        let output = Result::Done(&b""[..], Literal::Real(::std::f64::MAX));
+        let input  = Span::new(b"179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        let output = Result::Done(
+            Span::new_at(b"", 309, 1, 310),
+            Literal::Real(Token::new(::std::f64::MAX, input))
+        );
 
         assert_eq!(decimal(input), output);
         assert_eq!(integer(input), output);
@@ -853,8 +955,11 @@ mod tests {
 
     #[test]
     fn case_invalid_decimal_overflow_to_infinity() {
-        let input  = b"1797693134862315700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-        let output = Result::Done(&b""[..], Literal::Real(::std::f64::INFINITY));
+        let input  = Span::new(b"1797693134862315700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        let output = Result::Done(
+            Span::new_at(b"", 310, 1, 311),
+            Literal::Real(Token::new(::std::f64::INFINITY, input))
+        );
 
         assert_eq!(decimal(input), output);
         assert_eq!(integer(input), output);
@@ -863,8 +968,11 @@ mod tests {
 
     #[test]
     fn case_hexadecimal_lowercase_x() {
-        let input  = b"0x2a";
-        let output = Result::Done(&b""[..], Literal::Integer(42i64));
+        let input  = Span::new(b"0x2a");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Integer(Token::new(42i64, input))
+        );
 
         assert_eq!(hexadecimal(input), output);
         assert_eq!(integer(input), output);
@@ -873,8 +981,11 @@ mod tests {
 
     #[test]
     fn case_hexadecimal_uppercase_x() {
-        let input  = b"0X2a";
-        let output = Result::Done(&b""[..], Literal::Integer(42i64));
+        let input  = Span::new(b"0X2a");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Integer(Token::new(42i64, input))
+        );
 
         assert_eq!(hexadecimal(input), output);
         assert_eq!(integer(input), output);
@@ -883,8 +994,11 @@ mod tests {
 
     #[test]
     fn case_hexadecimal_uppercase_alpha() {
-        let input  = b"0x2A";
-        let output = Result::Done(&b""[..], Literal::Integer(42i64));
+        let input  = Span::new(b"0x2A");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Integer(Token::new(42i64, input))
+        );
 
         assert_eq!(hexadecimal(input), output);
         assert_eq!(integer(input), output);
@@ -893,28 +1007,37 @@ mod tests {
 
     #[test]
     fn case_invalid_hexadecimal_no_number() {
-        let input  = b"0x";
-        let output = Result::Done(&b"x"[..], Literal::Integer(0i64));
+        let input  = Span::new(b"0x");
+        let output = Result::Done(
+            Span::new_at(b"x", 1, 1, 2),
+            Literal::Integer(Token::new(0i64, Span::new(b"0")))
+        );
 
-        assert_eq!(hexadecimal(input), Result::Error(Error::Position(ErrorKind::Complete, &b""[..])));
+        assert_eq!(hexadecimal(input), Result::Error(Error::Code(ErrorKind::RegexpFind)));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_invalid_hexadecimal_not_in_base() {
-        let input  = b"0xg";
-        let output = Result::Done(&b"xg"[..], Literal::Integer(0i64));
+        let input  = Span::new(b"0xg");
+        let output = Result::Done(
+            Span::new_at(b"xg", 1, 1, 2),
+            Literal::Integer(Token::new(0i64, Span::new(b"0")))
+        );
 
-        assert_eq!(hexadecimal(input), Result::Error(Error::Position(ErrorKind::HexDigit, &b"g"[..])));
+        assert_eq!(hexadecimal(input), Result::Error(Error::Code(ErrorKind::RegexpFind)));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_hexadecimal_maximum_integer_value() {
-        let input  = b"0x7fffffffffffffff";
-        let output = Result::Done(&b""[..], Literal::Integer(::std::i64::MAX));
+        let input  = Span::new(b"0x7fffffffffffffff");
+        let output = Result::Done(
+            Span::new_at(b"", 18, 1, 19),
+            Literal::Integer(Token::new(::std::i64::MAX, input))
+        );
 
         assert_eq!(hexadecimal(input), output);
         assert_eq!(integer(input), output);
@@ -923,18 +1046,24 @@ mod tests {
 
     #[test]
     fn case_invalid_hexadecimal_overflow() {
-        let input  = b"0x8000000000000000";
-        let output = Result::Done(&b"x8000000000000000"[..], Literal::Integer(0i64));
+        let input  = Span::new(b"0x8000000000000000");
+        let output = Result::Done(
+            Span::new_at(b"x8000000000000000", 1, 1, 2),
+            Literal::Integer(Token::new(0i64, Span::new(b"0")))
+        );
 
-        assert_eq!(hexadecimal(input), Result::Error(Error::Position(ErrorKind::MapRes, &b"0x8000000000000000"[..])));
+        assert_eq!(hexadecimal(input), Result::Error(Error::Position(ErrorKind::MapRes, Span::new(b"0x8000000000000000"))));
         assert_eq!(integer(input), output);
         assert_eq!(literal(input), output);
     }
 
     #[test]
     fn case_exponential() {
-        let input  = b"123.456e+78";
-        let output = Result::Done(&b""[..], Literal::Real(123.456e78f64));
+        let input  = Span::new(b"123.456e+78");
+        let output = Result::Done(
+            Span::new_at(b"", 11, 1, 12),
+            Literal::Real(Token::new(123.456e78f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -942,8 +1071,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_rational_and_fractional_part() {
-        let input  = b"123.456";
-        let output = Result::Done(&b""[..], Literal::Real(123.456f64));
+        let input  = Span::new(b"123.456");
+        let output = Result::Done(
+            Span::new_at(b"", 7, 1, 8),
+            Literal::Real(Token::new(123.456f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -951,8 +1083,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_rational_part() {
-        let input  = b"123.";
-        let output = Result::Done(&b""[..], Literal::Real(123.0f64));
+        let input  = Span::new(b"123.");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Real(Token::new(123.0f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -960,8 +1095,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_fractional_part() {
-        let input  = b".456";
-        let output = Result::Done(&b""[..], Literal::Real(0.456f64));
+        let input  = Span::new(b".456");
+        let output = Result::Done(
+            Span::new_at(b"", 4, 1, 5),
+            Literal::Real(Token::new(0.456f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -969,8 +1107,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_rational_and_exponent_part_with_lowercase_e() {
-        let input  = b"123.e78";
-        let output = Result::Done(&b""[..], Literal::Real(123e78f64));
+        let input  = Span::new(b"123.e78");
+        let output = Result::Done(
+            Span::new_at(b"", 7, 1, 8),
+            Literal::Real(Token::new(123e78f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -978,8 +1119,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_integer_rational_and_exponent_part() {
-        let input  = b"123e78";
-        let output = Result::Done(&b""[..], Literal::Real(123e78f64));
+        let input  = Span::new(b"123e78");
+        let output = Result::Done(
+            Span::new_at(b"", 6, 1, 7),
+            Literal::Real(Token::new(123e78f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -987,8 +1131,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_rational_and_exponent_part_with_uppercase_e() {
-        let input  = b"123.E78";
-        let output = Result::Done(&b""[..], Literal::Real(123e78f64));
+        let input  = Span::new(b"123.E78");
+        let output = Result::Done(
+            Span::new_at(b"", 7, 1, 8),
+            Literal::Real(Token::new(123e78f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -996,8 +1143,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_rational_and_unsigned_exponent_part() {
-        let input  = b"123.e78";
-        let output = Result::Done(&b""[..], Literal::Real(123e78f64));
+        let input  = Span::new(b"123.e78");
+        let output = Result::Done(
+            Span::new_at(b"", 7, 1, 8),
+            Literal::Real(Token::new(123e78f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -1005,8 +1155,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_rational_and_positive_exponent_part() {
-        let input  = b"123.e+78";
-        let output = Result::Done(&b""[..], Literal::Real(123e78f64));
+        let input  = Span::new(b"123.e+78");
+        let output = Result::Done(
+            Span::new_at(b"", 8, 1, 9),
+            Literal::Real(Token::new(123e78f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -1014,8 +1167,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_rational_and_negative_exponent_part() {
-        let input  = b"123.e-78";
-        let output = Result::Done(&b""[..], Literal::Real(123e-78f64));
+        let input  = Span::new(b"123.e-78");
+        let output = Result::Done(
+            Span::new_at(b"", 8, 1, 9),
+            Literal::Real(Token::new(123e-78f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -1023,8 +1179,11 @@ mod tests {
 
     #[test]
     fn case_exponential_only_with_rational_and_negative_zero_exponent_part() {
-        let input  = b"123.e-0";
-        let output = Result::Done(&b""[..], Literal::Real(123f64));
+        let input  = Span::new(b"123.e-0");
+        let output = Result::Done(
+            Span::new_at(b"", 7, 1, 8),
+            Literal::Real(Token::new(123f64, input))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -1032,8 +1191,11 @@ mod tests {
 
     #[test]
     fn case_exponential_missing_exponent_part() {
-        let input  = b".7e";
-        let output = Result::Done(&b"e"[..], Literal::Real(0.7f64));
+        let input  = Span::new(b".7e");
+        let output = Result::Done(
+            Span::new_at(b"e", 2, 1, 3),
+            Literal::Real(Token::new(0.7f64, Span::new(b".7")))
+        );
 
         assert_eq!(exponential(input), output);
         assert_eq!(literal(input), output);
@@ -1041,16 +1203,19 @@ mod tests {
 
     #[test]
     fn case_invalid_exponential_only_the_dot() {
-        let input = b".";
+        let input = Span::new(b".");
 
         assert_eq!(exponential(input), Result::Error(Error::Code(ErrorKind::RegexpFind)));
-        assert_eq!(literal(input), Result::Error(Error::Position(ErrorKind::Alt, &b"."[..])));
+        assert_eq!(literal(input), Result::Error(Error::Position(ErrorKind::Alt, Span::new(b"."))));
     }
 
     #[test]
     fn case_string_single_quoted() {
-        let input  = b"'foobar'";
-        let output = Result::Done(&b""[..], Literal::String(b"foobar".to_vec()));
+        let input  = Span::new(b"'foobar'");
+        let output = Result::Done(
+            Span::new_at(b"", 8, 1, 9),
+            Literal::String(Token::new(b"foobar".to_vec(), input))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1059,8 +1224,11 @@ mod tests {
 
     #[test]
     fn case_string_single_quoted_escaped_quote() {
-        let input  = b"'foo\\'bar'";
-        let output = Result::Done(&b""[..], Literal::String(b"foo'bar".to_vec()));
+        let input  = Span::new(b"'foo\\'bar'");
+        let output = Result::Done(
+            Span::new_at(b"", 10, 1, 11),
+            Literal::String(Token::new(b"foo'bar".to_vec(), input))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1069,8 +1237,11 @@ mod tests {
 
     #[test]
     fn case_string_single_quoted_escaped_backslash() {
-        let input  = b"'foo\\\\bar'";
-        let output = Result::Done(&b""[..], Literal::String(b"foo\\bar".to_vec()));
+        let input  = Span::new(b"'foo\\\\bar'");
+        let output = Result::Done(
+            Span::new_at(b"", 10, 1, 11),
+            Literal::String(Token::new(b"foo\\bar".to_vec(), input))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1079,8 +1250,11 @@ mod tests {
 
     #[test]
     fn case_string_single_quoted_escaped_any() {
-        let input  = b"'foo\\nbar'";
-        let output = Result::Done(&b""[..], Literal::String(b"foo\\nbar".to_vec()));
+        let input  = Span::new(b"'foo\\nbar'");
+        let output = Result::Done(
+            Span::new_at(b"", 10, 1, 11),
+            Literal::String(Token::new(b"foo\\nbar".to_vec(), input))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1089,8 +1263,11 @@ mod tests {
 
     #[test]
     fn case_string_single_quoted_escaped_many() {
-        let input  = b"'\\'f\\oo\\\\bar\\\\'";
-        let output = Result::Done(&b""[..], Literal::String(b"'f\\oo\\bar\\".to_vec()));
+        let input  = Span::new(b"'\\'f\\oo\\\\bar\\\\'");
+        let output = Result::Done(
+            Span::new_at(b"", 15, 1, 16),
+            Literal::String(Token::new(b"'f\\oo\\bar\\".to_vec(), input))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1099,8 +1276,11 @@ mod tests {
 
     #[test]
     fn case_string_single_quoted_empty() {
-        let input  = b"''";
-        let output = Result::Done(&b""[..], Literal::String(Vec::new()));
+        let input  = Span::new(b"''");
+        let output = Result::Done(
+            Span::new_at(b"", 2, 1, 3),
+            Literal::String(Token::new(Vec::new(), input))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1109,8 +1289,11 @@ mod tests {
 
     #[test]
     fn case_string_binary_single_quoted() {
-        let input  = b"b'foobar'";
-        let output = Result::Done(&b""[..], Literal::String(b"foobar".to_vec()));
+        let input  = Span::new(b"b'foobar'");
+        let output = Result::Done(
+            Span::new_at(b"", 9, 1, 10),
+            Literal::String(Token::new(b"foobar".to_vec(), input.slice(1..)))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1119,8 +1302,11 @@ mod tests {
 
     #[test]
     fn case_string_binary_uppercase_single_quoted() {
-        let input  = b"B'foobar'";
-        let output = Result::Done(&b""[..], Literal::String(b"foobar".to_vec()));
+        let input  = Span::new(b"B'foobar'");
+        let output = Result::Done(
+            Span::new_at(b"", 9, 1, 10),
+            Literal::String(Token::new(b"foobar".to_vec(), input.slice(1..)))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1129,8 +1315,11 @@ mod tests {
 
     #[test]
     fn case_string_binary_single_quoted_escaped_many() {
-        let input  = b"b'\\'f\\oo\\\\bar'";
-        let output = Result::Done(&b""[..], Literal::String(b"'f\\oo\\bar".to_vec()));
+        let input  = Span::new(b"b'\\'f\\oo\\\\bar'");
+        let output = Result::Done(
+            Span::new_at(b"", 14, 1, 15),
+            Literal::String(Token::new(b"'f\\oo\\bar".to_vec(), input.slice(1..)))
+        );
 
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
@@ -1139,8 +1328,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_single_quoted_too_short() {
-        let input  = b"'";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"'");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_single_quoted(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32))));
         assert_eq!(string(input), output);
@@ -1149,8 +1338,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_single_quoted_opening_character() {
-        let input  = b"foobar'";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"foobar'");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_single_quoted(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1159,8 +1348,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_single_quoted_closing_character() {
-        let input  = b"'foobar";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"'foobar");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_single_quoted(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1169,8 +1358,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_single_quoted_closing_character_is_a_backslash() {
-        let input  = b"'foobar\\";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"'foobar\\");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_single_quoted(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1179,8 +1368,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_single_quoted_too_short() {
-        let input  = b"b'";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"b'");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_single_quoted(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32))));
         assert_eq!(string(input), output);
@@ -1189,8 +1378,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_uppercase_single_quoted_too_short() {
-        let input  = b"B'";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"B'");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_single_quoted(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32))));
         assert_eq!(string(input), output);
@@ -1199,8 +1388,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_single_quoted_opening_character() {
-        let input  = b"bb'";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"bb'");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_single_quoted(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1209,8 +1398,11 @@ mod tests {
 
     #[test]
     fn case_string_nowdoc() {
-        let input  = b"<<<'FOO'\nhello \n  world \nFOO;\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \n  world ".to_vec()));
+        let input  = Span::new(b"<<<'FOO'\nhello \n  world \nFOO;\n");
+        let output = Result::Done(
+            Span::new_at(b"", 30, 5, 1),
+            Literal::String(Token::new(b"hello \n  world ".to_vec(), input))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1219,8 +1411,11 @@ mod tests {
 
     #[test]
     fn case_string_nowdoc_crlf() {
-        let input  = b"<<<'FOO'\r\nhello \r\n  world \r\nFOO;\r\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \r\n  world ".to_vec()));
+        let input  = Span::new(b"<<<'FOO'\r\nhello \r\n  world \r\nFOO;\r\n");
+        let output = Result::Done(
+            Span::new_at(b"", 34, 5, 1),
+            Literal::String(Token::new(b"hello \r\n  world ".to_vec(), input))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1229,8 +1424,11 @@ mod tests {
 
     #[test]
     fn case_string_nowdoc_without_semi_colon() {
-        let input  = b"<<<'FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \n  world ".to_vec()));
+        let input  = Span::new(b"<<<'FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Done(
+            Span::new_at(b"", 29, 5, 1),
+            Literal::String(Token::new(b"hello \n  world ".to_vec(), input))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1239,8 +1437,11 @@ mod tests {
 
     #[test]
     fn case_string_nowdoc_without_semi_colon_crlf() {
-        let input  = b"<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \r\n  world ".to_vec()));
+        let input  = Span::new(b"<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n");
+        let output = Result::Done(
+            Span::new_at(b"", 33, 5, 1),
+            Literal::String(Token::new(b"hello \r\n  world ".to_vec(), input))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1249,8 +1450,11 @@ mod tests {
 
     #[test]
     fn case_string_nowdoc_empty() {
-        let input  = b"<<<'FOO'\nFOO\n";
-        let output = Result::Done(&b""[..], Literal::String(Vec::new()));
+        let input  = Span::new(b"<<<'FOO'\nFOO\n");
+        let output = Result::Done(
+            Span::new_at(b"", 13, 3, 1),
+            Literal::String(Token::new(Vec::new(), input))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1259,8 +1463,11 @@ mod tests {
 
     #[test]
     fn case_string_nowdoc_empty_crlf() {
-        let input  = b"<<<'FOO'\r\nFOO\r\n";
-        let output = Result::Done(&b""[..], Literal::String(Vec::new()));
+        let input  = Span::new(b"<<<'FOO'\r\nFOO\r\n");
+        let output = Result::Done(
+            Span::new_at(b"", 15, 3, 1),
+            Literal::String(Token::new(Vec::new(), input))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1269,8 +1476,11 @@ mod tests {
 
     #[test]
     fn case_string_nowdoc_with_whitespaces_before_identifier() {
-        let input  = b"<<<   \t  'FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \n  world ".to_vec()));
+        let input  = Span::new(b"<<<   \t  'FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Done(
+            Span::new_at(b"", 35, 5, 1),
+            Literal::String(Token::new(b"hello \n  world ".to_vec(), input))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1279,8 +1489,11 @@ mod tests {
 
     #[test]
     fn case_string_nowdoc_with_whitespaces_before_identifier_crlf() {
-        let input  = b"<<<   \t  'FOO'\r\nhello \r\n  world \r\nFOO\r\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \r\n  world ".to_vec()));
+        let input  = Span::new(b"<<<   \t  'FOO'\r\nhello \r\n  world \r\nFOO\r\n");
+        let output = Result::Done(
+            Span::new_at(b"", 39, 5, 1),
+            Literal::String(Token::new(b"hello \r\n  world ".to_vec(), input))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1289,8 +1502,11 @@ mod tests {
 
     #[test]
     fn case_string_binary_nowdoc() {
-        let input  = b"b<<<'FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \n  world ".to_vec()));
+        let input  = Span::new(b"b<<<'FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Done(
+            Span::new_at(b"", 30, 5, 1),
+            Literal::String(Token::new(b"hello \n  world ".to_vec(), input.slice(1..)))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1299,8 +1515,11 @@ mod tests {
 
     #[test]
     fn case_string_binary_nowdoc_crlf() {
-        let input  = b"b<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \r\n  world ".to_vec()));
+        let input  = Span::new(b"b<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n");
+        let output = Result::Done(
+            Span::new_at(b"", 34, 5, 1),
+            Literal::String(Token::new(b"hello \r\n  world ".to_vec(), input.slice(1..)))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1309,8 +1528,11 @@ mod tests {
 
     #[test]
     fn case_string_binary_uppercase_nowdoc() {
-        let input  = b"B<<<'FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \n  world ".to_vec()));
+        let input  = Span::new(b"B<<<'FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Done(
+            Span::new_at(b"", 30, 5, 1),
+            Literal::String(Token::new(b"hello \n  world ".to_vec(), input.slice(1..)))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1319,8 +1541,11 @@ mod tests {
 
     #[test]
     fn case_string_binary_uppercase_nowdoc_crlf() {
-        let input  = b"B<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n";
-        let output = Result::Done(&b""[..], Literal::String(b"hello \r\n  world ".to_vec()));
+        let input  = Span::new(b"B<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n");
+        let output = Result::Done(
+            Span::new_at(b"", 34, 5, 1),
+            Literal::String(Token::new(b"hello \r\n  world ".to_vec(), input.slice(1..)))
+        );
 
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
@@ -1329,8 +1554,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_too_short() {
-        let input  = b"<<<'A'\nA";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'A'\nA");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32))));
         assert_eq!(string(input), output);
@@ -1339,8 +1564,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_opening_character() {
-        let input  = b"<<FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1349,8 +1574,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_opening_character_missing_first_quote() {
-        let input  = b"<<<FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1359,8 +1584,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_opening_character_missing_second_quote() {
-        let input  = b"<<<'FOO\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'FOO\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1369,8 +1594,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_invalid_identifier() {
-        let input  = b"<<<'42'\nhello \n  world \n42\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'42'\nhello \n  world \n42\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidDelimiterIdentifier as u32))));
         assert_eq!(string(input), output);
@@ -1379,8 +1604,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_partially_invalid_identifier() {
-        let input  = b"<<<'F O O'\nhello \n  world \nF O O\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'F O O'\nhello \n  world \nF O O\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1389,8 +1614,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_opening_character_missing_newline() {
-        let input  = b"<<<'FOO'hello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'FOO'hello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1399,8 +1624,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_closing_character() {
-        let input  = b"<<<'FOO'\nhello \n  world \nFO;\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'FOO'\nhello \n  world \nFO;\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1409,8 +1634,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_closing_character_no_semi_colon_no_newline() {
-        let input  = b"<<<'FOO'\nhello \n  world \nFOO";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'FOO'\nhello \n  world \nFOO");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1419,8 +1644,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_closing_character_no_semi_colon_no_newline_crlf() {
-        let input  = b"<<<'FOO'\r\nhello \r\n  world \r\nFOO";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'FOO'\r\nhello \r\n  world \r\nFOO");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1429,8 +1654,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_closing_character_no_newline() {
-        let input  = b"<<<'FOO'\nhello \n  world \nFOO;";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'FOO'\nhello \n  world \nFOO;");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1439,8 +1664,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_closing_character_no_newline_crlf() {
-        let input  = b"<<<'FOO'\r\nhello \r\n  world \r\nFOO;";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'FOO'\r\nhello \r\n  world \r\nFOO;");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1449,8 +1674,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_nowdoc_closing_character_missing_lf_in_crlf() {
-        let input  = b"<<<'FOO'\r\nhello \r\n  world \r\nFOO\r";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"<<<'FOO'\r\nhello \r\n  world \r\nFOO\r");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1459,8 +1684,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_nowdoc_too_short() {
-        let input  = b"b<<<'A'\nA";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"b<<<'A'\nA");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32))));
         assert_eq!(string(input), output);
@@ -1469,8 +1694,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_nowdoc_opening_character() {
-        let input  = b"b<<FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"b<<FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1479,8 +1704,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_nowdoc_opening_character_missing_first_quote() {
-        let input  = b"b<<<FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"b<<<FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1489,8 +1714,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_nowdoc_opening_character_missing_second_quote() {
-        let input  = b"b<<<'FOO\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"b<<<'FOO\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1499,8 +1724,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_uppercase_nowdoc_too_short() {
-        let input  = b"B<<<'A'\nA";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"B<<<'A'\nA");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::TooShort as u32))));
         assert_eq!(string(input), output);
@@ -1509,8 +1734,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_uppercase_nowdoc_opening_character() {
-        let input  = b"B<<FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"B<<FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1519,8 +1744,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_uppercase_nowdoc_opening_character_missing_first_quote() {
-        let input  = b"B<<<FOO'\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"B<<<FOO'\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);
@@ -1529,8 +1754,8 @@ mod tests {
 
     #[test]
     fn case_invalid_string_binary_uppercase_nowdoc_opening_character_missing_second_quote() {
-        let input  = b"B<<<'FOO\nhello \n  world \nFOO\n";
-        let output = Result::Error(Error::Position(ErrorKind::Alt, &input[..]));
+        let input  = Span::new(b"B<<<'FOO\nhello \n  world \nFOO\n");
+        let output = Result::Error(Error::Position(ErrorKind::Alt, input));
 
         assert_eq!(string_nowdoc(input), Result::Error(Error::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
         assert_eq!(string(input), output);

--- a/source/rules/mod.rs
+++ b/source/rules/mod.rs
@@ -41,10 +41,11 @@ pub mod statements;
 pub mod tokens;
 pub mod whitespaces;
 
-use super::ast;
+use super::ast::Expression;
 use super::internal::*;
+use super::tokens::Span;
 
-pub fn root(input: &[u8]) -> ast::Expression {
+pub fn root(input: Span) -> Expression {
     match expressions::expression(input) {
         Result::Done(_, ast) => ast,
         _ => panic!("Youhouuu")
@@ -55,21 +56,26 @@ pub fn root(input: &[u8]) -> ast::Expression {
 #[cfg(test)]
 mod tests {
     use super::root;
-    use super::super::ast;
+    use super::super::ast::{
+        Expression,
+        Literal
+    };
+    use super::super::tokens::{
+        Span,
+        Token
+    };
 
     #[test]
     fn case_root() {
-        assert_eq!(
-            root(b"'Hello, World!'"),
-            ast::Expression::Literal(
-                ast::Literal::String(b"Hello, World!".to_vec())
-            )
-        );
+        let input  = Span::new(b"'Hello, World!'");
+        let output = Expression::Literal(Literal::String(Token::new(b"Hello, World!".to_vec(), input)));
+
+        assert_eq!(root(input), output);
     }
 
     #[test]
     #[should_panic(expected = "Youhouuu")]
     fn case_root_panic() {
-        root(b"!");
+        root(Span::new(b"!"));
     }
 }

--- a/source/rules/skip.rs
+++ b/source/rules/skip.rs
@@ -52,11 +52,18 @@ named_attr!(
         # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::rules::skip::skip;
+        use tagua_parser::tokens::Span;
 
         # fn main () {
         assert_eq!(
-            skip(b\"/* foo */ \\n\\thello\"),
-            Result::Done(&b\"hello\"[..], vec![&b\" foo \"[..], &b\" \\n\\t\"[..]])
+            skip(Span::new(b\"/* foo */ \\n\\thello\")),
+            Result::Done(
+                Span::new_at(b\"hello\", 12, 2, 2),
+                vec![
+                    Span::new_at(b\" foo \", 2, 1, 3),
+                    Span::new_at(b\" \\n\\t\", 9, 1, 10)
+                ]
+            )
         );
         # }
         ```

--- a/source/rules/skip.rs
+++ b/source/rules/skip.rs
@@ -60,7 +60,7 @@ named_attr!(
         # }
         ```
     "],
-    pub skip< Vec<&[u8]> >,
+    pub skip<Vec<&[u8]>>,
     many0!(
         alt!(
             comment

--- a/source/rules/statements/function.rs
+++ b/source/rules/statements/function.rs
@@ -101,33 +101,37 @@ named_attr!(
             Variable
         };
         use tagua_parser::rules::statements::function::function;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            function(b\"function &f($x, \\\\I\\\\J $y, int &$z): O { return; }\"),
+            function(Span::new(b\"function &f($x, \\\\I\\\\J $y, int &$z): O { return; }\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 48, 1, 49),
                 Statement::Function(
                     Function {
-                        name  : &b\"f\"[..],
+                        name  : Span::new_at(b\"f\", 10, 1, 11),
                         inputs: Arity::Finite(vec![
                             Parameter {
                                 ty   : Ty::Copy(None),
-                                name : Variable(&b\"x\"[..]),
+                                name : Variable(Span::new_at(b\"x\", 13, 1, 14)),
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![&b\"I\"[..], &b\"J\"[..]]))),
-                                name : Variable(&b\"y\"[..]),
+                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b\"I\", 17, 1, 18), Span::new_at(b\"J\", 19, 1, 20)]))),
+                                name : Variable(Span::new_at(b\"y\", 22, 1, 23)),
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Reference(Some(Name::FullyQualified(vec![&b\"int\"[..]]))),
-                                name : Variable(&b\"z\"[..]),
+                                ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b\"int\", 25, 1, 26)]))),
+                                name : Variable(Span::new_at(b\"z\", 31, 1, 32)),
                                 value: None
                             }
                         ]),
-                        output: Ty::Reference(Some(Name::Unqualified(&b\"O\"[..]))),
+                        output: Ty::Reference(Some(Name::Unqualified(Span::new_at(b\"O\", 35, 1, 36)))),
                         body  : vec![Statement::Return]
                     }
                 )
@@ -152,24 +156,28 @@ named_attr!(
             Variable
         };
         use tagua_parser::rules::statements::function::function;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            function(b\"function f($x, int ...$y) { return; }\"),
+            function(Span::new(b\"function f($x, int ...$y) { return; }\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 37, 1, 38),
                 Statement::Function(
                     Function {
-                        name  : &b\"f\"[..],
+                        name  : Span::new_at(b\"f\", 9, 1, 10),
                         inputs: Arity::Infinite(vec![
                             Parameter {
                                 ty   : Ty::Copy(None),
-                                name : Variable(&b\"x\"[..]),
+                                name : Variable(Span::new_at(b\"x\", 12, 1, 13)),
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![&b\"int\"[..]]))),
-                                name : Variable(&b\"y\"[..]),
+                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b\"int\", 15, 1, 16)]))),
+                                name : Variable(Span::new_at(b\"y\", 23, 1, 24)),
                                 value: None
                             }
                         ]),
@@ -226,26 +234,30 @@ named_attr!(
             Variable
         };
         use tagua_parser::rules::statements::function::parameters;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            parameters(b\"($x, \\\\I\\\\J $y, int &$z)\"),
+            parameters(Span::new(b\"($x, \\\\I\\\\J $y, int &$z)\")),
             Result::Done(
-                &b\"\"[..],
+                Span::new_at(b\"\", 22, 1, 23),
                 Arity::Finite(vec![
                     Parameter {
                         ty   : Ty::Copy(None),
-                        name : Variable(&b\"x\"[..]),
+                        name : Variable(Span::new_at(b\"x\", 2, 1, 3)),
                         value: None
                     },
                     Parameter {
-                        ty   : Ty::Copy(Some(Name::FullyQualified(vec![&b\"I\"[..], &b\"J\"[..]]))),
-                        name : Variable(&b\"y\"[..]),
+                        ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b\"I\", 6, 1, 7), Span::new_at(b\"J\", 8, 1, 9)]))),
+                        name : Variable(Span::new_at(b\"y\", 11, 1, 12)),
                         value: None
                     },
                     Parameter {
-                        ty   : Ty::Reference(Some(Name::FullyQualified(vec![&b\"int\"[..]]))),
-                        name : Variable(&b\"z\"[..]),
+                        ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b\"int\", 14, 1, 15)]))),
+                        name : Variable(Span::new_at(b\"z\", 20, 1, 21)),
                         value: None
                     }
                 ])
@@ -393,11 +405,18 @@ named!(
         use tagua_parser::Result;
         use tagua_parser::ast::Name;
         use tagua_parser::rules::statements::function::native_type;
+        use tagua_parser::tokens::{
+            Span,
+            Token
+        };
 
         # fn main() {
         assert_eq!(
-            native_type(b\"int\"),
-            Result::Done(&b\"\"[..], Name::FullyQualified(vec![&b\"int\"[..]]))
+            native_type(Span::new(b\"int\")),
+            Result::Done(
+                Span::new_at(b\"\", 3, 1, 4),
+                Name::FullyQualified(vec![Span::new(b\"int\")])
+            )
         );
         # }
         ```

--- a/source/rules/statements/mod.rs
+++ b/source/rules/statements/mod.rs
@@ -41,7 +41,7 @@ use super::super::ast::Statement;
 use super::super::tokens;
 
 named!(
-    pub compound_statement< Vec<Statement> >,
+    pub compound_statement<Vec<Statement>>,
     map_res!(
         terminated!(
             preceded!(

--- a/source/rules/statements/mod.rs
+++ b/source/rules/statements/mod.rs
@@ -39,14 +39,15 @@ pub mod function;
 
 use super::super::ast::Statement;
 use super::super::tokens;
+use super::super::tokens::Span;
 
 named!(
-    pub compound_statement<Vec<Statement>>,
+    pub compound_statement<Span, Vec<Statement>>,
     map_res!(
         terminated!(
             preceded!(
                 tag!(tokens::LEFT_CURLY_BRACKET),
-                opt!(first!(tag!("return;")))
+                opt!(first!(tag!(b"return;")))
             ),
             first!(tag!(tokens::RIGHT_CURLY_BRACKET))
         ),
@@ -57,7 +58,7 @@ named!(
 );
 
 named!(
-    pub statement<Statement>,
+    pub statement<Span, Statement>,
     alt!(
         call!(function::function)
     )

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -53,11 +53,21 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Variable;
         use tagua_parser::rules::tokens::variable;
+        use tagua_parser::tokens::Span;
 
         # fn main () {
-        assert_eq!(variable(b\"$foo\"), Result::Done(&b\"\"[..], Variable(&b\"foo\"[..])));
+        assert_eq!(
+            variable(Span::new(b\"$foo\")),
+            Result::Done(
+                Span::new_at(b\"\", 4, 1, 5),
+                Variable(Span::new_at(b\"foo\", 1, 1, 2))
+            )
+        );
         # }
         ```
+
+        Note that the variable prefix `$` is not present in the output
+        of the parser.
     "],
     pub variable<Span, Variable>,
     map_res!(
@@ -85,12 +95,20 @@ named_attr!(
         use tagua_parser::Result;
         use tagua_parser::ast::Name;
         use tagua_parser::rules::tokens::qualified_name;
+        use tagua_parser::tokens::Span;
 
         # fn main () {
         assert_eq!(
-            qualified_name(b\"Foo\\\\Bar\\\\Baz\"),
-            Result::Done(&b\"\"[..], Name::Qualified(vec![&b\"Foo\"[..], &b\"Bar\"[..], &b\"Baz\"[..]]))
-       );
+            qualified_name(Span::new(b\"Foo\\\\Bar\\\\Baz\")),
+            Result::Done(
+                Span::new_at(b\"\", 11, 1, 12),
+                Name::Qualified(vec![
+                    Span::new_at(b\"Foo\", 0, 1, 1),
+                    Span::new_at(b\"Bar\", 4, 1, 5),
+                    Span::new_at(b\"Baz\", 8, 1, 9)
+                ])
+            )
+        );
         # }
         ```
     "],
@@ -153,9 +171,16 @@ named_attr!(
         # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::rules::tokens::name;
+        use tagua_parser::tokens::Span;
 
         # fn main () {
-        assert_eq!(name(b\"foo\"), Result::Done(&b\"\"[..], &b\"foo\"[..]));
+        assert_eq!(
+            name(Span::new(b\"foo\")),
+            Result::Done(
+                Span::new_at(b\"\", 3, 1, 4),
+                Span::new(b\"foo\")
+            )
+        );
         # }
         ```
     "],

--- a/source/rules/whitespaces.rs
+++ b/source/rules/whitespaces.rs
@@ -47,9 +47,16 @@ named_attr!(
         # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::rules::whitespaces::whitespace;
+        use tagua_parser::tokens::Span;
 
         # fn main () {
-        assert_eq!(whitespace(b\"\\n \\r\\tabc\"), Result::Done(&b\"abc\"[..], &b\"\\n \\r\\t\"[..]));
+        assert_eq!(
+            whitespace(Span::new(b\"\\n \\r\\tabc\")),
+            Result::Done(
+                Span::new_at(b\"abc\", 4, 2, 4),
+                Span::new(b\"\\n \\r\\t\")
+            )
+        );
         # }
         ```
     "],

--- a/source/rules/whitespaces.rs
+++ b/source/rules/whitespaces.rs
@@ -35,6 +35,8 @@
 //! in the [Grammar chapter, White Space
 //! section](https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#white-space).
 
+use super::super::tokens::Span;
+
 named_attr!(
     #[doc="
         Recognize all whitespaces.
@@ -51,10 +53,9 @@ named_attr!(
         # }
         ```
     "],
-    pub whitespace,
+    pub whitespace<Span, Span>,
     is_a!(" \t\n\r")
 );
-
 
 #[cfg(test)]
 mod tests {
@@ -63,55 +64,86 @@ mod tests {
         ErrorKind,
         Result
     };
+    use super::super::super::tokens::Span;
     use super::whitespace;
 
     #[test]
     fn case_whitespace_space() {
-        assert_eq!(whitespace(b"   "), Result::Done(&b""[..], &b"   "[..]));
+        let input  = Span::new(b"   ");
+        let output = Result::Done(Span::new_at(b"", 3, 1, 4), input);
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_whitespace_horizontal_tabulation() {
-        assert_eq!(whitespace(b"\t\t\t"), Result::Done(&b""[..], &b"\t\t\t"[..]));
+        let input  = Span::new(b"\t\t\t");
+        let output = Result::Done(Span::new_at(b"", 3, 1, 4), input);
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_whitespace_carriage_return_line_feed() {
-        assert_eq!(whitespace(b"\r\n\r\n\r\n"), Result::Done(&b""[..], &b"\r\n\r\n\r\n"[..]));
+        let input  = Span::new(b"\r\n\r\n\r\n");
+        let output = Result::Done(Span::new_at(b"", 6, 4, 1), input);
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_whitespace_carriage_return() {
-        assert_eq!(whitespace(b"\r\r\r"), Result::Done(&b""[..], &b"\r\r\r"[..]));
+        let input  = Span::new(b"\r\r\r");
+        let output = Result::Done(Span::new_at(b"", 3, 1, 4), input);
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_whitespace_line_feed() {
-        assert_eq!(whitespace(b"\n\n\n"), Result::Done(&b""[..], &b"\n\n\n"[..]));
+        let input  = Span::new(b"\n\n\n");
+        let output = Result::Done(Span::new_at(b"", 3, 4, 1), input);
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_whitespace_mixed() {
-        assert_eq!(whitespace(b"\n \n \r\t  \t\r\n\t \t\t"), Result::Done(&b""[..], &b"\n \n \r\t  \t\r\n\t \t\t"[..]));
+        let input  = Span::new(b"\n \n \r\t  \t\r\n\t \t\t");
+        let output = Result::Done(Span::new_at(b"", 15, 4, 5), input);
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_whitespace_with_a_tail() {
-        assert_eq!(whitespace(b"\n \n \r\t  \t\r\n\t \t\tabc "), Result::Done(&b"abc "[..], &b"\n \n \r\t  \t\r\n\t \t\t"[..]));
+        let input  = Span::new(b"\n \n \r\t  \t\r\n\t \t\tabc ");
+        let output = Result::Done(Span::new_at(b"abc ", 15, 4, 5), Span::new(b"\n \n \r\t  \t\r\n\t \t\t"));
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_whitespace_too_short() {
-        assert_eq!(whitespace(b""), Result::Done(&b""[..], &b""[..]));
+        let input  = Span::new(b"");
+        let output = Result::Done(Span::new_at(b"", 0, 1, 1), input);
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_invalid_whitespace_not_a_valid_whitespace() {
-        assert_eq!(whitespace(b"\xa0 "), Result::Error(Error::Position(ErrorKind::IsA, &b"\xa0 "[..])));
+        let input  = Span::new(b"\xa0 ");
+        let output = Result::Error(Error::Position(ErrorKind::IsA, input));
+
+        assert_eq!(whitespace(input), output);
     }
 
     #[test]
     fn case_invalid_whitespace_not_a_valid_character() {
-        assert_eq!(whitespace(b"abc\n \t"), Result::Error(Error::Position(ErrorKind::IsA, &b"abc\n \t"[..])));
+        let input  = Span::new(b"abc\n \t");
+        let output = Result::Error(Error::Position(ErrorKind::IsA, input));
+
+        assert_eq!(whitespace(input), output);
     }
 }

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -653,13 +653,17 @@ named_attr!(
         # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::tokens;
+        use tagua_parser::tokens::Span;
 
         # fn main () {
-        let output = Result::Done(&b\"\"[..], tokens::ECHO);
+        let output = Result::Done(
+            Span::new_at(b\"\", 4, 1, 5),
+            Span::new(tokens::ECHO)
+        );
 
-        assert_eq!(tokens::keywords(b\"echo\"), output);
-        assert_eq!(tokens::keywords(b\"ECHO\"), output);
-        assert_eq!(tokens::keywords(b\"EcHo\"), output);
+        assert_eq!(tokens::keywords(Span::new(b\"echo\")), output);
+        assert_eq!(tokens::keywords(Span::new(b\"ECHO\")), output);
+        assert_eq!(tokens::keywords(Span::new(b\"EcHo\")), output);
         # }
         ```
     "],

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -1055,11 +1055,16 @@ impl<'a, 'b> FindSubstring<Input<'b>> for Span<'a> {
         } else if substring_length == 1 {
             memchr::memchr(substring[0], self.slice)
         } else {
+            let max          = self.slice.len() - substring_length;
             let mut offset   = 0;
             let mut haystack = self.slice;
 
             while let Some(position) = memchr::memchr(substring[0], haystack) {
                 offset += position;
+
+                if offset > max {
+                    return None
+                }
 
                 if &haystack[position..position + substring_length] == substring {
                     return Some(offset);
@@ -1519,6 +1524,14 @@ mod tests {
         let output = Some(3);
 
         assert_eq!(input.find_substring(b"barb"), output);
+    }
+
+    #[test]
+    fn case_span_find_substring_out_of_bound() {
+        let input  = Span::new(b"abc");
+        let output = None;
+
+        assert_eq!(input.find_substring(b"cd"), output);
     }
 
     #[test]

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -760,7 +760,8 @@ pub struct Span<'a> {
 }
 
 impl<'a> Span<'a> {
-    /// Create a blank.
+    /// Create a span for a particular input with default `offset`,
+    /// `line`, and `column` values.
     ///
     /// `offset` starts at 0, `line` starts at 1, and `column` starts at 1.
     pub fn new(input: Input<'a>) -> Self {
@@ -770,6 +771,12 @@ impl<'a> Span<'a> {
             column: 1,
             slice : input
         }
+    }
+
+    /// Create a blank span.
+    /// This is strictly equivalent to `Span::new(b"")`.
+    pub fn empty() -> Self {
+        Self::new(b"")
     }
 
     /// Extract the entire slice of the span.
@@ -1150,6 +1157,39 @@ mod tests {
     #[test]
     fn case_invalid_keyword() {
         assert_eq!(keywords(b"hello"), Result::Error(Error::Position(ErrorKind::Alt, &b"hello"[..])));
+    }
+
+    #[test]
+    fn case_span_new() {
+        let input  = &b"foobar"[..];
+        let output = Span {
+            offset: 0,
+            line  : 1,
+            column: 1,
+            slice : input
+        };
+
+        assert_eq!(Span::new(input), output);
+    }
+
+    #[test]
+    fn case_span_empty() {
+        let output = Span {
+            offset: 0,
+            line  : 1,
+            column: 1,
+            slice : &b""[..]
+        };
+
+        assert_eq!(Span::empty(), output);
+    }
+
+    #[test]
+    fn case_span_as_slice() {
+        let input  = Span::new(b"foobar");
+        let output = &b"foobar"[..];
+
+        assert_eq!(input.as_slice(), output);
     }
 
     #[test]

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -764,6 +764,22 @@ impl<'a> Span<'a> {
     /// `line`, and `column` values.
     ///
     /// `offset` starts at 0, `line` starts at 1, and `column` starts at 1.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::tokens::Span;
+    ///
+    /// # fn main() {
+    /// let span = Span::new(b"foobar");
+    ///
+    /// assert_eq!(span.offset,     0);
+    /// assert_eq!(span.line,       1);
+    /// assert_eq!(span.column,     1);
+    /// assert_eq!(span.as_slice(), &b"foobar"[..]);
+    /// # }
+    /// ```
     pub fn new(input: Input<'a>) -> Self {
         Span {
             offset: 0,
@@ -773,13 +789,61 @@ impl<'a> Span<'a> {
         }
     }
 
+    /// Create a span for a particular input at a particular offset, line, and column.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::tokens::Span;
+    ///
+    /// # fn main() {
+    /// let span = Span::new_at(b"foobar", 1, 2, 3);
+    ///
+    /// assert_eq!(span.offset,     1);
+    /// assert_eq!(span.line,       2);
+    /// assert_eq!(span.column,     3);
+    /// assert_eq!(span.as_slice(), &b"foobar"[..]);
+    /// # }
+    /// ```
+    pub fn new_at(input: Input<'a>, offset: usize, line: u32, column: u16) -> Self {
+        Span {
+            offset: offset,
+            line  : line,
+            column: column,
+            slice : input
+        }
+    }
+
     /// Create a blank span.
     /// This is strictly equivalent to `Span::new(b"")`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::tokens::Span;
+    ///
+    /// # fn main() {
+    /// assert_eq!(Span::empty(), Span::new(b""));
+    /// # }
+    /// ```
     pub fn empty() -> Self {
         Self::new(b"")
     }
 
     /// Extract the entire slice of the span.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::tokens::Span;
+    ///
+    /// # fn main() {
+    /// assert_eq!(Span::new(b"foobar").as_slice(), &b"foobar"[..]);
+    /// # }
+    /// ```
     pub fn as_slice(&self) -> Input<'a> {
         self.slice
     }
@@ -987,12 +1051,10 @@ macro_rules! impl_slice_for_range {
             /// use nom::Slice;
             ///
             /// # fn main() {
-            /// let sliced_span = Span::new(b"foobar").slice(2..5);
-            ///
-            /// assert_eq!(sliced_span.offset,     2);
-            /// assert_eq!(sliced_span.line,       1);
-            /// assert_eq!(sliced_span.column,     3);
-            /// assert_eq!(sliced_span.as_slice(), &b"oba"[..]);
+            /// assert_eq!(
+            ///     Span::new(b"foobar").slice(2..5),
+            ///     Span::new_at(b"oba", 2, 1, 3)
+            /// );
             /// # }
             /// ```
             fn slice(&self, range: $range) -> Self {
@@ -1170,6 +1232,19 @@ mod tests {
         };
 
         assert_eq!(Span::new(input), output);
+    }
+
+    #[test]
+    fn case_span_new_at() {
+        let input  = &b"foobar"[..];
+        let output = Span {
+            offset: 1,
+            line  : 2,
+            column: 3,
+            slice : input
+        };
+
+        assert_eq!(Span::new_at(input, 1, 2, 3), output);
     }
 
     #[test]

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -1410,7 +1410,7 @@ mod tests {
             Span {
                 offset: 25,
                 line  : 4,
-                column: 12, // dummy value
+                column: 12,
                 slice : &b""[..]
             },
             vec![

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -786,7 +786,7 @@ pub struct Span<'a> {
 
     /// The column number of the slice relatively to the input of the
     /// parser. It starts at column 1.
-    pub column: u16,
+    pub column: u32,
 
     /// The slice that is spanned.
     slice: Input<'a>
@@ -839,7 +839,7 @@ impl<'a> Span<'a> {
     /// assert_eq!(span.as_slice(), &b"foobar"[..]);
     /// # }
     /// ```
-    pub fn new_at(input: Input<'a>, offset: usize, line: u32, column: u16) -> Self {
+    pub fn new_at(input: Input<'a>, offset: usize, line: u32, column: u32) -> Self {
         Span {
             offset: offset,
             line  : line,
@@ -1154,11 +1154,11 @@ macro_rules! impl_slice_for_range {
 
                 let next_column =
                     if number_of_newlines == 0 {
-                        self.column + next_offset as u16
+                        self.column + next_offset as u32
                     } else {
                         match memchr::memrchr(b'\n', consumed) {
                             Some(last_newline_position) => {
-                                (next_offset - last_newline_position) as u16
+                                (next_offset - last_newline_position) as u32
                             },
 
                             None => 0 // unreachable


### PR DESCRIPTION
Work in Progress.

I would like to thank @fflorent for the original idea and code. The goal is to declare a `Span` structure that can be used as an input for nom parsers. Each `Span` collects the offset, line, and column numbers for each slices computed by parsers. Then, the `Token` structure is used to attached a span to any “data”.

It works. We are using `bytecount::count` to count the number of lines. And we are using `memchr::memrchr` to count the number of columns. All counting are made relatively to the previous span, so we are not iterating over the whole input each time. The offset is computed based on the `nom::Offset` features.

We can compile tagua-parser as follows:

```sh
$ cargo build --release --features simd
```

or:

```sh
$ cargo build --release --features avx
```

to respectively enable SIMD or AVX optimisations. `bytecount` performance depends on these features.

Next step: See how it feets with the AST.