### PR TITLE
Literal: Remove null and boolean parsers

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -55,39 +55,6 @@ pub struct Addition<'a> {
 /// A literal represents a fixed value, aka an atom.
 #[derive(Debug, PartialEq)]
 pub enum Literal<'a> {
-    /// A boolean, either `true` or `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate tagua_parser;
-    /// use tagua_parser::Result;
-    /// use tagua_parser::ast::Literal;
-    /// use tagua_parser::rules::literals::literal;
-    /// use tagua_parser::tokens::{
-    ///     Span,
-    ///     Token
-    /// };
-    ///
-    /// # fn main() {
-    /// assert_eq!(
-    ///     literal(Span::new(b"true")),
-    ///     Result::Done(
-    ///         Span::new_at(b"", 4, 1, 5),
-    ///         Literal::Boolean(Token::new(true, Span::new(b"true")))
-    ///     )
-    /// );
-    /// assert_eq!(
-    ///     literal(Span::new(b"false")),
-    ///     Result::Done(
-    ///         Span::new_at(b"", 5, 1, 6),
-    ///         Literal::Boolean(Token::new(false, Span::new(b"false")))
-    ///     )
-    /// );
-    /// # }
-    /// ```
-    Boolean(Token<'a, bool>),
-
     /// An integer, for instance a binary, octal, decimal or hexadecimal number.
     ///
     /// # Examples

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -135,32 +135,6 @@ pub enum Literal<'a> {
     /// ```
     Integer(Token<'a, i64>),
 
-    /// A null value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # extern crate tagua_parser;
-    /// use tagua_parser::Result;
-    /// use tagua_parser::ast::Literal;
-    /// use tagua_parser::rules::literals::literal;
-    /// use tagua_parser::tokens::{
-    ///     Span,
-    ///     Token
-    /// };
-    ///
-    /// # fn main() {
-    /// assert_eq!(
-    ///     literal(Span::new(b"null")),
-    ///     Result::Done(
-    ///         Span::new_at(b"", 4, 1, 5),
-    ///         Literal::Null(Token::new((), Span::new(b"null")))
-    ///     )
-    /// );
-    /// # }
-    /// ```
-    Null(Token<'a, ()>),
-
     /// A real, for instance an exponential number.
     ///
     /// # Examples

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -62,7 +62,7 @@ named_attr!(
     #[doc="
         Recognize all kind of literals.
 
-        A literal is either a null, a boolean, an expotential, an integer or an integer.
+        A literal is either a boolean, an expotential, an integer or an integer.
 
         # Examples
 
@@ -89,52 +89,12 @@ named_attr!(
     "],
     pub literal<Span, Literal>,
     alt!(
-        null
-      | boolean
+        boolean
       | exponential
       | integer
       | string
     )
 );
-
-named_attr!(
-    #[doc="
-        Recognize a null value.
-
-        # Examples
-
-        ```
-        # extern crate tagua_parser;
-        use tagua_parser::Result;
-        use tagua_parser::ast::Literal;
-        use tagua_parser::rules::literals::null;
-        use tagua_parser::tokens::{
-            Span,
-            Token
-        };
-
-        # fn main () {
-        assert_eq!(
-            null(Span::new(b\"null\")),
-            Result::Done(
-                Span::new_at(b\"\", 4, 1, 5),
-                Literal::Null(Token::new((), Span::new(b\"null\")))
-            )
-        );
-        # }
-        ```
-    "],
-    pub null<Span, Literal>,
-    map_res!(
-        itag!(b"null"),
-        null_mapper
-    )
-);
-
-#[inline]
-fn null_mapper(span: Span) -> StdResult<Literal, ()> {
-    Ok(Literal::Null(Token::new((), span)))
-}
 
 named_attr!(
     #[doc="
@@ -704,7 +664,6 @@ mod tests {
         hexadecimal,
         integer,
         literal,
-        null,
         octal,
         string,
         string_nowdoc,
@@ -720,30 +679,6 @@ mod tests {
         Span,
         Token
     };
-
-    #[test]
-    fn case_null() {
-        let input  = Span::new(b"null");
-        let output = Result::Done(
-            Span::new_at(b"", 4, 1, 5),
-            Literal::Null(Token::new((), input))
-        );
-
-        assert_eq!(null(input), output);
-        assert_eq!(literal(input), output);
-    }
-
-    #[test]
-    fn case_null_case_insensitive() {
-        let input  = Span::new(b"NuLl");
-        let output = Result::Done(
-            Span::new_at(b"", 4, 1, 5),
-            Literal::Null(Token::new((), Span::new(b"null")))
-        );
-
-        assert_eq!(null(input), output);
-        assert_eq!(literal(input), output);
-    }
 
     #[test]
     fn case_boolean_true() {

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -62,7 +62,7 @@ named_attr!(
     #[doc="
         Recognize all kind of literals.
 
-        A literal is either a boolean, an expotential, an integer or an integer.
+        A literal is either an expotential, an integer or a string.
 
         # Examples
 
@@ -89,51 +89,11 @@ named_attr!(
     "],
     pub literal<Span, Literal>,
     alt!(
-        boolean
-      | exponential
+        exponential
       | integer
       | string
     )
 );
-
-named_attr!(
-    #[doc="
-        Recognize a boolean.
-
-        # Examples
-
-        ```
-        # extern crate tagua_parser;
-        use tagua_parser::Result;
-        use tagua_parser::ast::Literal;
-        use tagua_parser::rules::literals::boolean;
-        use tagua_parser::tokens::{
-            Span,
-            Token
-        };
-
-        # fn main () {
-        assert_eq!(
-            boolean(Span::new(b\"true\")),
-            Result::Done(
-                Span::new_at(b\"\", 4, 1, 5),
-                Literal::Boolean(Token::new(true, Span::new(b\"true\")))
-            )
-        );
-        # }
-        ```
-    "],
-    pub boolean<Span, Literal>,
-    map_res!(
-        alt!(itag!(b"true") | itag!(b"false")),
-        boolean_mapper
-    )
-);
-
-#[inline]
-fn boolean_mapper(span: Span) -> StdResult<Literal, ()> {
-    Ok(Literal::Boolean(Token::new(span.as_slice()[0] == b't', span)))
-}
 
 named_attr!(
     #[doc="
@@ -658,7 +618,6 @@ mod tests {
     use super::{
         StringError,
         binary,
-        boolean,
         decimal,
         exponential,
         hexadecimal,
@@ -679,54 +638,6 @@ mod tests {
         Span,
         Token
     };
-
-    #[test]
-    fn case_boolean_true() {
-        let input  = Span::new(b"true");
-        let output = Result::Done(
-            Span::new_at(b"", 4, 1, 5),
-            Literal::Boolean(Token::new(true, input))
-        );
-
-        assert_eq!(boolean(input), output);
-        assert_eq!(literal(input), output);
-    }
-
-    #[test]
-    fn case_boolean_true_case_insensitive() {
-        let input  = Span::new(b"TrUe");
-        let output = Result::Done(
-            Span::new_at(b"", 4, 1, 5),
-            Literal::Boolean(Token::new(true, Span::new(b"true")))
-        );
-
-        assert_eq!(boolean(input), output);
-        assert_eq!(literal(input), output);
-    }
-
-    #[test]
-    fn case_boolean_false() {
-        let input  = Span::new(b"false");
-        let output = Result::Done(
-            Span::new_at(b"", 5, 1, 6),
-            Literal::Boolean(Token::new(false, input))
-        );
-
-        assert_eq!(boolean(input), output);
-        assert_eq!(literal(input), output);
-    }
-
-    #[test]
-    fn case_boolean_false_case_insensitive() {
-        let input  = Span::new(b"FaLsE");
-        let output = Result::Done(
-            Span::new_at(b"", 5, 1, 6),
-            Literal::Boolean(Token::new(false, Span::new(b"false")))
-        );
-
-        assert_eq!(boolean(input), output);
-        assert_eq!(literal(input), output);
-    }
 
     #[test]
     fn case_binary_lowercase_b() {

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -248,6 +248,25 @@ mod tests {
     }
 
     #[test]
+    fn case_special_unqualified_name() {
+        let tests = vec![
+            ("null", 4, 1, 5),
+            ("NuLl", 4, 1, 5),
+            ("true", 4, 1, 5),
+            ("TrUe", 4, 1, 5),
+            ("false", 5, 1, 6),
+            ("FaLsE", 5, 1, 6),
+        ];
+
+        for &(name, offset, line, column) in &tests {
+            let input  = Span::new(name.as_bytes());
+            let output = Result::Done(Span::new_at(b"", offset, line, column), Name::Unqualified(input));
+
+            assert_eq!(qualified_name(input), output);
+        }
+    }
+
+    #[test]
     fn case_invalid_unqualified_name() {
         let input1 = Span::new(b"class");
         let input2 = Span::new(b"ClAsS");
@@ -291,7 +310,7 @@ mod tests {
                 Span::new_at(b"Bar", 16, 2, 13)
             ])
         );
-        
+
         assert_eq!(qualified_name(input), output);
     }
 


### PR DESCRIPTION
Addresses https://github.com/tagua-vm/parser/issues/93.