### PR TITLE
Fail compilation of no documentation on a public item

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: rust
 
 matrix:
   include:
-    - rust: 1.14.0
-      os: linux
-      dist: trusty
-    - rust: 1.14.0
-      os: osx
     - rust: 1.15.0
       os: linux
       dist: trusty

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -53,6 +53,9 @@
 //! much as possible zero copy. We try to enforce the zero copy property to
 //! hold.
 
+// Force all public items to be documented.
+#![deny(missing_docs)]
+
 // Increase the macro recursion limit.
 #![recursion_limit="128"]
 

--- a/source/rules/mod.rs
+++ b/source/rules/mod.rs
@@ -45,6 +45,30 @@ use super::ast::Expression;
 use super::internal::*;
 use super::tokens::Span;
 
+/// The `root` parser is the axiom of the grammar, i.e. the entry
+/// point of all the parsers.
+///
+/// # Examples
+///
+/// ```
+/// # extern crate tagua_parser;
+/// use tagua_parser::ast::{
+///     Expression,
+///     Literal
+/// };
+/// use tagua_parser::tokens::{
+///     Span,
+///     Token
+/// };
+/// use tagua_parser::rules::root;
+///
+/// # fn main() {
+/// let input  = Span::new(b"'Hello, World!'");
+/// let output = Expression::Literal(Literal::String(Token::new(b"Hello, World!".to_vec(), input)));
+///
+/// assert_eq!(root(input), output);
+/// # }
+/// ```
 pub fn root(input: Span) -> Expression {
     match expressions::expression(input) {
         Result::Done(_, ast) => ast,

--- a/source/rules/statements/mod.rs
+++ b/source/rules/statements/mod.rs
@@ -41,7 +41,10 @@ use super::super::ast::Statement;
 use super::super::tokens;
 use super::super::tokens::Span;
 
-named!(
+named_attr!(
+    #[doc="
+        Recognize a group of statements.
+    "],
     pub compound_statement<Span, Vec<Statement>>,
     map_res!(
         terminated!(
@@ -58,6 +61,9 @@ named!(
 );
 
 named!(
+    #[doc="
+        Recognize a statement.
+    "],
     pub statement<Span, Statement>,
     alt!(
         call!(function::function)

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -767,6 +767,21 @@ pub struct Token<'a, T> {
 }
 
 impl<'a, T> Token<'a, T> {
+    /// Associate a span to a datum, i.e. to the token value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tagua_parser;
+    /// use tagua_parser::tokens::{
+    ///     Span,
+    ///     Token
+    /// };
+    ///
+    /// # fn main() {
+    /// let token = Token::new(42, Span::new(b"42"));
+    /// # }
+    /// ```
     pub fn new(value: T, span: Span<'a>) -> Self {
         Token {
             value: value,


### PR DESCRIPTION
If a public item is not documented, force the compiler to fail.