### PR TITLE
Literal: Avoid string copies by default

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -204,6 +204,12 @@ pub enum Literal<'a> {
 
     /// A string.
     ///
+    /// A string can borrow (`&[u8]`) or own (`Vec<u8>`) the data. It
+    /// is represented as a clone-on-write smart pointer. By default,
+    /// if the string does not contain any escaped character, it will
+    /// borrow its data. As soon as the string is extended, it will
+    /// own the data.
+    ///
     /// # Examples
     ///
     /// ```
@@ -219,10 +225,10 @@ pub enum Literal<'a> {
     ///
     /// # fn main() {
     /// assert_eq!(
-    ///     literal(Span::new(b"'foo\\'bar'")),
+    ///     literal(Span::new(b"'foobar'")),
     ///     Result::Done(
-    ///         Span::new_at(b"", 10, 1, 11),
-    ///         Literal::String(Token::new(Cow::from(&b"foo'bar"[..]), Span::new(b"'foo\\'bar'")))
+    ///         Span::new_at(b"", 8, 1, 9),
+    ///         Literal::String(Token::new(Cow::from(&b"foobar"[..]), Span::new(b"'foobar'")))
     ///     )
     /// );
     /// # }

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -208,6 +208,7 @@ pub enum Literal<'a> {
     ///
     /// ```
     /// # extern crate tagua_parser;
+    /// use std::borrow::Cow;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Literal;
     /// use tagua_parser::rules::literals::literal;
@@ -221,7 +222,7 @@ pub enum Literal<'a> {
     ///     literal(Span::new(b"'foo\\'bar'")),
     ///     Result::Done(
     ///         Span::new_at(b"", 10, 1, 11),
-    ///         Literal::String(Token::new(b"foo'bar".to_vec(), Span::new(b"'foo\\'bar'")))
+    ///         Literal::String(Token::new(Cow::from(&b"foo'bar"[..]), Span::new(b"'foo\\'bar'")))
     ///     )
     /// );
     /// # }
@@ -472,6 +473,7 @@ pub enum Expression<'a> {
     ///
     /// ```
     /// # extern crate tagua_parser;
+    /// use std::borrow::Cow;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal, Variable};
     /// use tagua_parser::rules::expressions::expression;
@@ -488,14 +490,14 @@ pub enum Expression<'a> {
     ///         Expression::Array(vec![
     ///             (
     ///                 None,
-    ///                 Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 1, 1, 2))))
+    ///                 Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 1, 1, 2))))
     ///             ),
     ///             (
     ///                 Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 8, 1, 9))))),
-    ///                 Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 14, 1, 15))))
+    ///                 Expression::Literal(Literal::String(Token::new(Cow::from(&b"bar"[..]), Span::new_at(b"'bar'", 14, 1, 15))))
     ///             ),
     ///             (
-    ///                 Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 21, 1, 22))))),
+    ///                 Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 21, 1, 22))))),
     ///                 Expression::Variable(Variable(Span::new_at(b"qux", 31, 1, 32)))
     ///             )
     ///         ])
@@ -513,6 +515,7 @@ pub enum Expression<'a> {
     ///
     /// ```
     /// # extern crate tagua_parser;
+    /// use std::borrow::Cow;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal, Variable};
     /// use tagua_parser::rules::expressions::expression;
@@ -527,7 +530,7 @@ pub enum Expression<'a> {
     ///     Result::Done(
     ///         Span::new_at(b"", 26, 1, 27),
     ///         Expression::Echo(vec![
-    ///             Expression::Literal(Literal::String(Token::new(b"foobar".to_vec(), Span::new_at(b"'foobar'", 5, 1, 6)))),
+    ///             Expression::Literal(Literal::String(Token::new(Cow::from(&b"foobar"[..]), Span::new_at(b"'foobar'", 5, 1, 6)))),
     ///             Expression::Variable(Variable(Span::new_at(b"bazqux", 16, 1, 17))),
     ///             Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 24, 1, 25))))
     ///         ])
@@ -544,6 +547,7 @@ pub enum Expression<'a> {
     ///
     /// ```
     /// # extern crate tagua_parser;
+    /// use std::borrow::Cow;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal};
     /// use tagua_parser::rules::expressions::expression;
@@ -560,7 +564,7 @@ pub enum Expression<'a> {
     ///         Expression::Empty(
     ///             Box::new(
     ///                 Expression::Literal(
-    ///                     Literal::String(Token::new(b"".to_vec(), Span::new_at(b"''", 6, 1, 7)))
+    ///                     Literal::String(Token::new(Cow::from(&b""[..]), Span::new_at(b"''", 6, 1, 7)))
     ///                 )
     ///             )
     ///         )
@@ -576,6 +580,7 @@ pub enum Expression<'a> {
     ///
     /// ```
     /// # extern crate tagua_parser;
+    /// use std::borrow::Cow;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal};
     /// use tagua_parser::rules::expressions::expression;
@@ -592,7 +597,7 @@ pub enum Expression<'a> {
     ///         Expression::Eval(
     ///             Box::new(
     ///                 Expression::Literal(
-    ///                     Literal::String(Token::new(b"1 + 2;".to_vec(), Span::new_at(b"'1 + 2;'", 5, 1, 6)))
+    ///                     Literal::String(Token::new(Cow::from(&b"1 + 2;"[..]), Span::new_at(b"'1 + 2;'", 5, 1, 6)))
     ///                 )
     ///             )
     ///         )
@@ -675,6 +680,7 @@ pub enum Expression<'a> {
     ///
     /// ```
     /// # extern crate tagua_parser;
+    /// use std::borrow::Cow;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal, Variable};
     /// use tagua_parser::rules::expressions::expression;
@@ -690,15 +696,15 @@ pub enum Expression<'a> {
     ///         Span::new_at(b"", 49, 1, 50),
     ///         Expression::List(vec![
     ///             Some((
-    ///                 Some(Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 5, 1, 6))))),
+    ///                 Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 5, 1, 6))))),
     ///                 Expression::Variable(Variable(Span::new_at(b"foo", 15, 1, 16)))
     ///             )),
     ///             Some((
-    ///                 Some(Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 20, 1, 21))))),
+    ///                 Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"bar"[..]), Span::new_at(b"'bar'", 20, 1, 21))))),
     ///                 Expression::Variable(Variable(Span::new_at(b"bar", 30, 1, 31)))
     ///             )),
     ///             Some((
-    ///                 Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 35, 1, 36))))),
+    ///                 Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 35, 1, 36))))),
     ///                 Expression::Variable(Variable(Span::new_at(b"baz", 45, 1, 46)))
     ///             ))
     ///         ])
@@ -751,6 +757,7 @@ pub enum Expression<'a> {
     ///
     /// ```
     /// # extern crate tagua_parser;
+    /// use std::borrow::Cow;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Literal};
     /// use tagua_parser::rules::expressions::expression;
@@ -764,7 +771,7 @@ pub enum Expression<'a> {
     ///     expression(Span::new(b"'Hello, World!'")),
     ///     Result::Done(
     ///         Span::new_at(b"", 15, 1, 16),
-    ///         Expression::Literal(Literal::String(Token::new(b"Hello, World!".to_vec(), Span::new(b"'Hello, World!'"))))
+    ///         Expression::Literal(Literal::String(Token::new(Cow::from(&b"Hello, World!"[..]), Span::new(b"'Hello, World!'"))))
     ///     )
     /// );
     /// # }

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -31,6 +31,7 @@
 
 //! Structures that will constitute the Abstract Syntax Tree.
 
+use std::borrow::Cow;
 use super::tokens::{
     Span,
     Token
@@ -225,7 +226,7 @@ pub enum Literal<'a> {
     /// );
     /// # }
     /// ```
-    String(Token<'a, Vec<u8>>)
+    String(Token<'a, Cow<'a, [u8]>>)
 }
 
 /// A variable.

--- a/source/rules/expressions/mod.rs
+++ b/source/rules/expressions/mod.rs
@@ -49,6 +49,7 @@ named_attr!(
 
         ```
         # extern crate tagua_parser;
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::expression;
@@ -66,7 +67,7 @@ named_attr!(
                     Expression::Literal(
                         Literal::String(
                             Token::new(
-                                b\"Hello, World!\".to_vec(),
+                                Cow::from(&b\"Hello, World!\"[..]),
                                 Span::new_at(b\"'Hello, World!'\", 5, 1, 6)
                             )
                         )

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -88,6 +88,7 @@ named_attr!(
 
         ```
         # extern crate tagua_parser;
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::primary;
@@ -105,7 +106,7 @@ named_attr!(
                     Expression::Literal(
                         Literal::String(
                             Token::new(
-                                b\"Hello, World!\".to_vec(),
+                                Cow::from(&b\"Hello, World!\"[..]),
                                 Span::new_at(b\"'Hello, World!'\", 5, 1, 6)
                             )
                         )
@@ -157,6 +158,7 @@ named_attr!(
 
         ```
         # extern crate tagua_parser;
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal, Variable};
         use tagua_parser::rules::expressions::primaries::array;
@@ -176,7 +178,7 @@ named_attr!(
                         Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b\"42\", 1, 1, 2))))
                     ),
                     (
-                        Some(Expression::Literal(Literal::String(Token::new(b\"foo\".to_vec(), Span::new_at(b\"'foo'\", 5, 1, 6))))),
+                        Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b\"foo\"[..]), Span::new_at(b\"'foo'\", 5, 1, 6))))),
                         Expression::Variable(Variable(Span::new_at(b\"bar\", 15, 1, 16)))
                     )
                 ])
@@ -283,6 +285,7 @@ named_attr!(
         # Examples
 
         ```
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic;
@@ -300,7 +303,7 @@ named_attr!(
                     Expression::Literal(
                         Literal::String(
                             Token::new(
-                                b\"Hello, World!\".to_vec(),
+                                Cow::from(&b\"Hello, World!\"[..]),
                                 Span::new_at(b\"'Hello, World!'\", 5, 1, 6)
                             )
                         )
@@ -345,6 +348,7 @@ named_attr!(
         # Examples
 
         ```
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_echo;
@@ -359,8 +363,8 @@ named_attr!(
             Result::Done(
                 Span::new_at(b\"\", 24, 1, 25),
                 Expression::Echo(vec![
-                    Expression::Literal(Literal::String(Token::new(b\"Hello,\".to_vec(), Span::new_at(b\"'Hello,'\", 5, 1, 6)))),
-                    Expression::Literal(Literal::String(Token::new(b\" World!\".to_vec(), Span::new_at(b\"' World!'\", 15, 1, 16))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b\"Hello,\"[..]), Span::new_at(b\"'Hello,'\", 5, 1, 6)))),
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b\" World!\"[..]), Span::new_at(b\"' World!'\", 15, 1, 16))))
                 ])
             )
         );
@@ -404,6 +408,7 @@ named_attr!(
         # Examples
 
         ```
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal, Variable};
         use tagua_parser::rules::expressions::primaries::intrinsic_list;
@@ -419,11 +424,11 @@ named_attr!(
                 Span::new_at(b\"\", 34, 1, 35),
                 Expression::List(vec![
                     Some((
-                        Some(Expression::Literal(Literal::String(Token::new(b\"foo\".to_vec(), Span::new_at(b\"'foo'\", 5, 1, 6))))),
+                        Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b\"foo\"[..]), Span::new_at(b\"'foo'\", 5, 1, 6))))),
                         Expression::Variable(Variable(Span::new_at(b\"foo\", 15, 1, 16)))
                     )),
                     Some((
-                        Some(Expression::Literal(Literal::String(Token::new(b\"bar\".to_vec(), Span::new_at(b\"'bar'\", 20, 1, 21))))),
+                        Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b\"bar\"[..]), Span::new_at(b\"'bar'\", 20, 1, 21))))),
                         Expression::Variable(Variable(Span::new_at(b\"bar\", 30, 1, 31)))
                     ))
                 ])
@@ -597,6 +602,7 @@ named_attr!(
         # Examples
 
         ```
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_empty;
@@ -614,7 +620,7 @@ named_attr!(
                     Box::new(
                         Expression::Literal(
                             Literal::String(
-                                Token::new(b\"foo\".to_vec(), Span::new_at(b\"'foo'\", 6, 1, 7))
+                                Token::new(Cow::from(&b\"foo\"[..]), Span::new_at(b\"'foo'\", 6, 1, 7))
                             )
                         )
                     )
@@ -652,6 +658,7 @@ named_attr!(
         # Examples
 
         ```
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_eval;
@@ -668,7 +675,7 @@ named_attr!(
                 Expression::Eval(
                     Box::new(
                         Expression::Literal(
-                            Literal::String(Token::new(b\"1 + 2\".to_vec(), Span::new_at(b\"'1 + 2'\", 5, 1, 6)))
+                            Literal::String(Token::new(Cow::from(&b\"1 + 2\"[..]), Span::new_at(b\"'1 + 2'\", 5, 1, 6)))
                         )
                     )
                 )
@@ -841,6 +848,7 @@ named_attr!(
         # Examples
 
         ```
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
         use tagua_parser::rules::expressions::primaries::intrinsic_print;
@@ -858,7 +866,7 @@ named_attr!(
                     Box::new(
                         Expression::Literal(
                             Literal::String(
-                                Token::new(b\"Hello, World!\".to_vec(), Span::new_at(b\"'Hello, World!'\", 6, 1, 7))
+                                Token::new(Cow::from(&b\"Hello, World!\"[..]), Span::new_at(b\"'Hello, World!'\", 6, 1, 7))
                             )
                         )
                     )
@@ -1083,6 +1091,7 @@ fn into_anonymous_function<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use super::{
         anonymous_function,
         array,
@@ -1142,7 +1151,7 @@ mod tests {
                     None,
                     Expression::Literal(
                         Literal::String(
-                            Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 1, 1, 2))
+                            Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 1, 1, 2))
                         )
                     )
                 )
@@ -1162,7 +1171,7 @@ mod tests {
             Expression::Array(vec![
                 (
                     Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 1, 1, 2))))),
-                    Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 7, 1, 8))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 7, 1, 8))))
                 )
             ])
         );
@@ -1180,14 +1189,14 @@ mod tests {
             Expression::Array(vec![
                 (
                     None,
-                    Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 1, 1, 2))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 1, 1, 2))))
                 ),
                 (
                     Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 8, 1, 9))))),
-                    Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 14, 1, 15))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"bar"[..]), Span::new_at(b"'bar'", 14, 1, 15))))
                 ),
                 (
-                    Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 21, 1, 22))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 21, 1, 22))))),
                     Expression::Variable(Variable(Span::new_at(b"qux", 31, 1, 32)))
                 )
             ])
@@ -1242,7 +1251,7 @@ mod tests {
             Expression::Array(vec![
                 (
                     None,
-                    Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 1, 1, 2))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 1, 1, 2))))
                 ),
                 (
                     Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 8, 1, 9))))),
@@ -1256,14 +1265,14 @@ mod tests {
                             Expression::Array(vec![
                                 (
                                     Some(Expression::Literal(Literal::Integer(Token::new(11i64, Span::new_at(b"11", 29, 1, 30))))),
-                                    Expression::Literal(Literal::String(Token::new(b"13".to_vec(), Span::new_at(b"'13'", 35, 1, 36))))
+                                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"13"[..]), Span::new_at(b"'13'", 35, 1, 36))))
                                 )
                             ])
                         )
                     ])
                 ),
                 (
-                    Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 43, 1, 44))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 43, 1, 44))))),
                     Expression::Variable(Variable(Span::new_at(b"qux", 53, 1, 54)))
                 )
             ])
@@ -1338,7 +1347,7 @@ mod tests {
                     None,
                     Expression::Literal(
                         Literal::String(
-                            Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 6, 1, 7))
+                            Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 6, 1, 7))
                         )
                     )
                 )
@@ -1358,7 +1367,7 @@ mod tests {
             Expression::Array(vec![
                 (
                     Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 6, 1, 7))))),
-                    Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 12, 1, 13))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 12, 1, 13))))
                 )
             ])
         );
@@ -1376,14 +1385,14 @@ mod tests {
             Expression::Array(vec![
                 (
                     None,
-                    Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 6, 1, 7))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 6, 1, 7))))
                 ),
                 (
                     Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 13, 1, 14))))),
-                    Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 19, 1, 20))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"bar"[..]), Span::new_at(b"'bar'", 19, 1, 20))))
                 ),
                 (
-                    Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 26, 1, 27))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 26, 1, 27))))),
                     Expression::Variable(Variable(Span::new_at(b"qux", 36, 1, 37)))
                 )
             ])
@@ -1428,7 +1437,7 @@ mod tests {
             Expression::Array(vec![
                 (
                     None,
-                    Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 6, 1, 7))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 6, 1, 7))))
                 ),
                 (
                     Some(Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 13, 1, 14))))),
@@ -1442,14 +1451,14 @@ mod tests {
                             Expression::Array(vec![
                                 (
                                     Some(Expression::Literal(Literal::Integer(Token::new(11i64, Span::new_at(b"11", 44, 1, 45))))),
-                                    Expression::Literal(Literal::String(Token::new(b"13".to_vec(), Span::new_at(b"'13'", 50, 1, 51))))
+                                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"13"[..]), Span::new_at(b"'13'", 50, 1, 51))))
                                 )
                             ])
                         )
                     ])
                 ),
                 (
-                    Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 58, 1, 59))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 58, 1, 59))))),
                     Expression::Variable(Variable(Span::new_at(b"qux", 68, 1, 69)))
                 )
             ])
@@ -1520,7 +1529,7 @@ mod tests {
             Span::new_at(b"", 15, 1, 16),
             Expression::Literal(
                 Literal::String(
-                    Token::new(b"Hello, World!".to_vec(), input)
+                    Token::new(Cow::from(&b"Hello, World!"[..]), input)
                 )
             )
         );
@@ -1535,7 +1544,7 @@ mod tests {
         let output = Result::Done(
             Span::new_at(b"", 23, 1, 24),
             Expression::Echo(vec![
-                Expression::Literal(Literal::String(Token::new(b"foobar".to_vec(), Span::new_at(b"'foobar'", 15, 1, 16))))
+                Expression::Literal(Literal::String(Token::new(Cow::from(&b"foobar"[..]), Span::new_at(b"'foobar'", 15, 1, 16))))
             ])
         );
 
@@ -1552,7 +1561,7 @@ mod tests {
         let output = Result::Done(
             Span::new_at(b"", 40, 2, 5),
             Expression::Echo(vec![
-                Expression::Literal(Literal::String(Token::new(b"foobar".to_vec(), Span::new_at(b"'foobar'", 15, 1, 16)))),
+                Expression::Literal(Literal::String(Token::new(Cow::from(&b"foobar"[..]), Span::new_at(b"'foobar'", 15, 1, 16)))),
                 Expression::Variable(Variable(Span::new_at(b"bazqux", 27, 1, 28))),
                 Expression::Literal(Literal::Integer(Token::new(42i64, Span::new_at(b"42", 38, 2, 3))))
             ])
@@ -1594,7 +1603,7 @@ mod tests {
             Span::new_at(b"", 19, 1, 20),
             Expression::List(vec![
                 Some((
-                    Some(Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 5, 1, 6))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 5, 1, 6))))),
                     Expression::Variable(Variable(Span::new_at(b"foo", 15, 1, 16)))
                 ))
             ])
@@ -1614,15 +1623,15 @@ mod tests {
             Span::new_at(b"", 49, 1, 50),
             Expression::List(vec![
                 Some((
-                    Some(Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 5, 1, 6))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 5, 1, 6))))),
                     Expression::Variable(Variable(Span::new_at(b"foo", 15, 1, 16)))
                 )),
                 Some((
-                    Some(Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 20, 1, 21))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"bar"[..]), Span::new_at(b"'bar'", 20, 1, 21))))),
                     Expression::Variable(Variable(Span::new_at(b"bar", 30, 1, 31)))
                 )),
                 Some((
-                    Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 35, 1, 36))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 35, 1, 36))))),
                     Expression::Variable(Variable(Span::new_at(b"baz", 45, 1, 46)))
                 ))
             ])
@@ -1652,11 +1661,11 @@ mod tests {
             Span::new_at(b"", 35, 1, 36),
             Expression::List(vec![
                 Some((
-                    Some(Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 5, 1, 6))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 5, 1, 6))))),
                     Expression::Variable(Variable(Span::new_at(b"foo", 15, 1, 16)))
                 )),
                 Some((
-                    Some(Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 20, 1, 21))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"bar"[..]), Span::new_at(b"'bar'", 20, 1, 21))))),
                     Expression::Variable(Variable(Span::new_at(b"bar", 30, 1, 31)))
                 ))
             ])
@@ -1676,16 +1685,16 @@ mod tests {
             Span::new_at(b"", 57, 1, 58),
             Expression::List(vec![
                 Some((
-                    Some(Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 5, 1, 6))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 5, 1, 6))))),
                     Expression::List(vec![
                         Some((
-                            Some(Expression::Literal(Literal::String(Token::new(b"bar".to_vec(), Span::new_at(b"'bar'", 19, 1, 20))))),
+                            Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"bar"[..]), Span::new_at(b"'bar'", 19, 1, 20))))),
                             Expression::Variable(Variable(Span::new_at(b"bar", 29, 1, 30)))
                         ))
                     ])
                 )),
                 Some((
-                    Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 35, 1, 36))))),
+                    Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 35, 1, 36))))),
                     Expression::List(vec![
                         None,
                         Some((
@@ -1817,7 +1826,7 @@ mod tests {
                     None,
                     Expression::List(vec![
                         Some((
-                            Some(Expression::Literal(Literal::String(Token::new(b"baz".to_vec(), Span::new_at(b"'baz'", 28, 1, 29))))),
+                            Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"baz"[..]), Span::new_at(b"'baz'", 28, 1, 29))))),
                             Expression::Variable(Variable(Span::new_at(b"baz", 38, 1, 39)))
                         ))
                     ])
@@ -1934,7 +1943,7 @@ mod tests {
             Expression::Empty(
                 Box::new(
                     Expression::Literal(
-                        Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 6, 1, 7)))
+                        Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 6, 1, 7)))
                     )
                 )
             )
@@ -1988,7 +1997,7 @@ mod tests {
             Expression::Eval(
                 Box::new(
                     Expression::Literal(
-                        Literal::String(Token::new(b"1 + 2;".to_vec(), Span::new_at(b"'1 + 2;'", 5, 1, 6)))
+                        Literal::String(Token::new(Cow::from(&b"1 + 2;"[..]), Span::new_at(b"'1 + 2;'", 5, 1, 6)))
                     )
                 )
             )
@@ -2242,7 +2251,7 @@ mod tests {
             Span::new_at(b"", 24, 1, 25),
             Expression::Print(
                 Box::new(
-                    Expression::Literal(Literal::String(Token::new(b"foobar".to_vec(), Span::new_at(b"'foobar'", 16, 1, 17))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"foobar"[..]), Span::new_at(b"'foobar'", 16, 1, 17))))
                 )
             )
         );
@@ -2273,7 +2282,7 @@ mod tests {
             Span::new_at(b"", 22, 1, 23),
             Expression::Print(
                 Box::new(
-                    Expression::Literal(Literal::String(Token::new(b"foobar".to_vec(), Span::new_at(b"'foobar'", 10, 1, 11))))
+                    Expression::Literal(Literal::String(Token::new(Cow::from(&b"foobar"[..]), Span::new_at(b"'foobar'", 10, 1, 11))))
                 )
             )
         );

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -1351,6 +1351,26 @@ mod tests {
     }
 
     #[test]
+    fn case_string_single_quoted_without_copy() {
+        let input = Span::new(b"'foobar'tail");
+
+        match string_single_quoted(input) {
+            Result::Done(
+                Span { .. },
+                Literal::String(
+                    Token { value: Cow::Borrowed(..), .. }
+                )
+            ) => {
+                assert!(true);
+            },
+
+            _ => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
     fn case_string_single_quoted_escaped_quote() {
         let input  = Span::new(b"'foo\\'bar'tail");
         let output = Result::Done(
@@ -1366,6 +1386,26 @@ mod tests {
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
         assert_eq!(literal(input), output);
+    }
+
+    #[test]
+    fn case_string_single_quoted_escaped_quote_with_copy() {
+        let input = Span::new(b"'foo\\'bar'tail");
+
+        match string_single_quoted(input) {
+            Result::Done(
+                Span { .. },
+                Literal::String(
+                    Token { value: Cow::Owned(..), .. }
+                )
+            ) => {
+                assert!(true);
+            },
+
+            _ => {
+                assert!(false);
+            }
+        }
     }
 
     #[test]
@@ -1387,6 +1427,26 @@ mod tests {
     }
 
     #[test]
+    fn case_string_single_quoted_escaped_backslash_with_copy() {
+        let input = Span::new(b"'foo\\\\bar'tail");
+
+        match string_single_quoted(input) {
+            Result::Done(
+                Span { .. },
+                Literal::String(
+                    Token { value: Cow::Owned(..), .. }
+                )
+            ) => {
+                assert!(true);
+            },
+
+            _ => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
     fn case_string_single_quoted_escaped_any() {
         let input  = Span::new(b"'foo\\nbar'tail");
         let output = Result::Done(
@@ -1402,6 +1462,26 @@ mod tests {
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
         assert_eq!(literal(input), output);
+    }
+
+    #[test]
+    fn case_string_single_quoted_escaped_any_without_copy() {
+        let input = Span::new(b"'foo\\nbar'tail");
+
+        match string_single_quoted(input) {
+            Result::Done(
+                Span { .. },
+                Literal::String(
+                    Token { value: Cow::Borrowed(..), .. }
+                )
+            ) => {
+                assert!(true);
+            },
+
+            _ => {
+                assert!(false);
+            }
+        }
     }
 
     #[test]
@@ -1438,6 +1518,26 @@ mod tests {
         assert_eq!(string_single_quoted(input), output);
         assert_eq!(string(input), output);
         assert_eq!(literal(input), output);
+    }
+
+    #[test]
+    fn case_string_single_quoted_empty_without_copy() {
+        let input = Span::new(b"''tail");
+
+        match string_single_quoted(input) {
+            Result::Done(
+                Span { .. },
+                Literal::String(
+                    Token { value: Cow::Borrowed(..), .. }
+                )
+            ) => {
+                assert!(true);
+            },
+
+            _ => {
+                assert!(false);
+            }
+        }
     }
 
     #[test]
@@ -1565,6 +1665,26 @@ mod tests {
         assert_eq!(string_nowdoc(input), output);
         assert_eq!(string(input), output);
         assert_eq!(literal(input), output);
+    }
+
+    #[test]
+    fn case_string_nowdoc_without_copy() {
+        let input = Span::new(b"<<<'FOO'\nhello \n  world \nFOO;\ntail");
+
+        match string_nowdoc(input) {
+            Result::Done(
+                Span { .. },
+                Literal::String(
+                    Token { value: Cow::Borrowed(..), .. }
+                )
+            ) => {
+                assert!(true);
+            },
+
+            _ => {
+                assert!(false);
+            }
+        }
     }
 
     #[test]

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -493,6 +493,7 @@ named_attr!(
 
         ```
         # extern crate tagua_parser;
+        use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::string;
@@ -506,7 +507,7 @@ named_attr!(
             string(Span::new(b\"'foobar'\")),
             Result::Done(
                 Span::new_at(b\"\", 8, 1, 9),
-                Literal::String(Token::new(b\"foobar\".to_vec(), Span::new(b\"'foobar'\")))
+                Literal::String(Token::new(Cow::from(&b\"foobar\"[..]), Span::new(b\"'foobar'\")))
             )
         );
         # }
@@ -715,6 +716,7 @@ fn string_nowdoc(span: Span) -> Result<Span, Literal> {
 #[cfg(test)]
 mod tests {
     use nom::Slice;
+    use std::borrow::Cow;
     use super::{
         StringError,
         binary,
@@ -1337,7 +1339,7 @@ mod tests {
             Span::new_at(b"tail", 8, 1, 9),
             Literal::String(
                 Token::new(
-                    b"foobar".to_vec(),
+                    Cow::from(&b"foobar"[..]),
                     Span::new(b"'foobar'")
                 )
             )
@@ -1355,7 +1357,7 @@ mod tests {
             Span::new_at(b"tail", 10, 1, 11),
             Literal::String(
                 Token::new(
-                    b"foo'bar".to_vec(),
+                    Cow::from(&b"foo'bar"[..]),
                     Span::new(b"'foo\\'bar'")
                 )
             )
@@ -1373,7 +1375,7 @@ mod tests {
             Span::new_at(b"tail", 10, 1, 11),
             Literal::String(
                 Token::new(
-                    b"foo\\bar".to_vec(),
+                    Cow::from(&b"foo\\bar"[..]),
                     Span::new(b"'foo\\\\bar'")
                 )
             )
@@ -1391,7 +1393,7 @@ mod tests {
             Span::new_at(b"tail", 10, 1, 11),
             Literal::String(
                 Token::new(
-                    b"foo\\nbar".to_vec(),
+                    Cow::from(&b"foo\\nbar"[..]),
                     Span::new(b"'foo\\nbar'")
                 )
             )
@@ -1409,7 +1411,7 @@ mod tests {
             Span::new_at(b"tail", 15, 1, 16),
             Literal::String(
                 Token::new(
-                    b"'f\\oo\\bar\\".to_vec(),
+                    Cow::from(&b"'f\\oo\\bar\\"[..]),
                     Span::new(b"'\\'f\\oo\\\\bar\\\\'")
                 )
             )
@@ -1427,7 +1429,7 @@ mod tests {
             Span::new_at(b"tail", 2, 1, 3),
             Literal::String(
                 Token::new(
-                    Vec::new(),
+                    Cow::from(&b""[..]),
                     Span::new(b"''")
                 )
             )
@@ -1443,7 +1445,7 @@ mod tests {
         let input  = Span::new(b"b'foobar'");
         let output = Result::Done(
             Span::new_at(b"", 9, 1, 10),
-            Literal::String(Token::new(b"foobar".to_vec(), input.slice(1..)))
+            Literal::String(Token::new(Cow::from(&b"foobar"[..]), input.slice(1..)))
         );
 
         assert_eq!(string_single_quoted(input), output);
@@ -1456,7 +1458,7 @@ mod tests {
         let input  = Span::new(b"B'foobar'");
         let output = Result::Done(
             Span::new_at(b"", 9, 1, 10),
-            Literal::String(Token::new(b"foobar".to_vec(), input.slice(1..)))
+            Literal::String(Token::new(Cow::from(&b"foobar"[..]), input.slice(1..)))
         );
 
         assert_eq!(string_single_quoted(input), output);
@@ -1469,7 +1471,7 @@ mod tests {
         let input  = Span::new(b"b'\\'f\\oo\\\\bar'");
         let output = Result::Done(
             Span::new_at(b"", 14, 1, 15),
-            Literal::String(Token::new(b"'f\\oo\\bar".to_vec(), input.slice(1..)))
+            Literal::String(Token::new(Cow::from(&b"'f\\oo\\bar"[..]), input.slice(1..)))
         );
 
         assert_eq!(string_single_quoted(input), output);
@@ -1554,7 +1556,7 @@ mod tests {
             Span::new_at(b"tail", 30, 5, 1),
             Literal::String(
                 Token::new(
-                    b"hello \n  world ".to_vec(),
+                    Cow::from(&b"hello \n  world "[..]),
                     Span::new(b"<<<'FOO'\nhello \n  world \nFOO;\n")
                 )
             )
@@ -1572,7 +1574,7 @@ mod tests {
             Span::new_at(b"tail", 34, 5, 1),
             Literal::String(
                 Token::new(
-                    b"hello \r\n  world ".to_vec(),
+                    Cow::from(&b"hello \r\n  world "[..]),
                     Span::new(b"<<<'FOO'\r\nhello \r\n  world \r\nFOO;\r\n")
                 )
             )
@@ -1590,7 +1592,7 @@ mod tests {
             Span::new_at(b"tail", 29, 5, 1),
             Literal::String(
                 Token::new(
-                    b"hello \n  world ".to_vec(),
+                    Cow::from(&b"hello \n  world "[..]),
                     Span::new(b"<<<'FOO'\nhello \n  world \nFOO\n")
                 )
             )
@@ -1608,7 +1610,7 @@ mod tests {
             Span::new_at(b"tail", 33, 5, 1),
             Literal::String(
                 Token::new(
-                    b"hello \r\n  world ".to_vec(),
+                    Cow::from(&b"hello \r\n  world "[..]),
                     Span::new(b"<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n")
                 )
             )
@@ -1626,7 +1628,7 @@ mod tests {
             Span::new_at(b"tail", 13, 3, 1),
             Literal::String(
                 Token::new(
-                    Vec::new(),
+                    Cow::from(&b""[..]),
                     Span::new(b"<<<'FOO'\nFOO\n")
                 )
             )
@@ -1644,7 +1646,7 @@ mod tests {
             Span::new_at(b"tail", 15, 3, 1),
             Literal::String(
                 Token::new(
-                    Vec::new(),
+                    Cow::from(&b""[..]),
                     Span::new(b"<<<'FOO'\r\nFOO\r\n")
                 )
             )
@@ -1662,7 +1664,7 @@ mod tests {
             Span::new_at(b"tail", 35, 5, 1),
             Literal::String(
                 Token::new(
-                    b"hello \n  world ".to_vec(),
+                    Cow::from(&b"hello \n  world "[..]),
                     Span::new(b"<<<   \t  'FOO'\nhello \n  world \nFOO\n")
                 )
             )
@@ -1680,7 +1682,7 @@ mod tests {
             Span::new_at(b"tail", 39, 5, 1),
             Literal::String(
                 Token::new(
-                    b"hello \r\n  world ".to_vec(),
+                    Cow::from(&b"hello \r\n  world "[..]),
                     Span::new(b"<<<   \t  'FOO'\r\nhello \r\n  world \r\nFOO\r\n")
                 )
             )
@@ -1696,7 +1698,7 @@ mod tests {
         let input  = Span::new(b"b<<<'FOO'\nhello \n  world \nFOO\n");
         let output = Result::Done(
             Span::new_at(b"", 30, 5, 1),
-            Literal::String(Token::new(b"hello \n  world ".to_vec(), input.slice(1..)))
+            Literal::String(Token::new(Cow::from(&b"hello \n  world "[..]), input.slice(1..)))
         );
 
         assert_eq!(string_nowdoc(input), output);
@@ -1709,7 +1711,7 @@ mod tests {
         let input  = Span::new(b"b<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n");
         let output = Result::Done(
             Span::new_at(b"", 34, 5, 1),
-            Literal::String(Token::new(b"hello \r\n  world ".to_vec(), input.slice(1..)))
+            Literal::String(Token::new(Cow::from(&b"hello \r\n  world "[..]), input.slice(1..)))
         );
 
         assert_eq!(string_nowdoc(input), output);
@@ -1722,7 +1724,7 @@ mod tests {
         let input  = Span::new(b"B<<<'FOO'\nhello \n  world \nFOO\n");
         let output = Result::Done(
             Span::new_at(b"", 30, 5, 1),
-            Literal::String(Token::new(b"hello \n  world ".to_vec(), input.slice(1..)))
+            Literal::String(Token::new(Cow::from(&b"hello \n  world "[..]), input.slice(1..)))
         );
 
         assert_eq!(string_nowdoc(input), output);
@@ -1735,7 +1737,7 @@ mod tests {
         let input  = Span::new(b"B<<<'FOO'\r\nhello \r\n  world \r\nFOO\r\n");
         let output = Result::Done(
             Span::new_at(b"", 34, 5, 1),
-            Literal::String(Token::new(b"hello \r\n  world ".to_vec(), input.slice(1..)))
+            Literal::String(Token::new(Cow::from(&b"hello \r\n  world "[..]), input.slice(1..)))
         );
 
         assert_eq!(string_nowdoc(input), output);

--- a/source/rules/mod.rs
+++ b/source/rules/mod.rs
@@ -52,6 +52,7 @@ use super::tokens::Span;
 ///
 /// ```
 /// # extern crate tagua_parser;
+/// use std::borrow::Cow;
 /// use tagua_parser::ast::{
 ///     Expression,
 ///     Literal
@@ -64,7 +65,7 @@ use super::tokens::Span;
 ///
 /// # fn main() {
 /// let input  = Span::new(b"'Hello, World!'");
-/// let output = Expression::Literal(Literal::String(Token::new(b"Hello, World!".to_vec(), input)));
+/// let output = Expression::Literal(Literal::String(Token::new(Cow::from(&b"Hello, World!"[..]), input)));
 ///
 /// assert_eq!(root(input), output);
 /// # }
@@ -79,6 +80,7 @@ pub fn root(input: Span) -> Expression {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use super::root;
     use super::super::ast::{
         Expression,
@@ -92,7 +94,7 @@ mod tests {
     #[test]
     fn case_root() {
         let input  = Span::new(b"'Hello, World!'");
-        let output = Expression::Literal(Literal::String(Token::new(b"Hello, World!".to_vec(), input)));
+        let output = Expression::Literal(Literal::String(Token::new(Cow::from(&b"Hello, World!"[..]), input)));
 
         assert_eq!(root(input), output);
     }

--- a/source/rules/statements/function.rs
+++ b/source/rules/statements/function.rs
@@ -468,6 +468,7 @@ fn into_function<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use super::{
         function,
         native_type,
@@ -793,7 +794,7 @@ mod tests {
                 Parameter {
                     ty   : Ty::Reference(None),
                     name : Variable(Span::new_at(b"x", 3, 1, 4)),
-                    value: Some(Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 7, 1, 8)))))
+                    value: Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 7, 1, 8)))))
                 }
             ])
         );
@@ -830,7 +831,7 @@ mod tests {
                     value: Some(
                         Expression::Array(vec![
                             (
-                                Some(Expression::Literal(Literal::String(Token::new(b"foo".to_vec(), Span::new_at(b"'foo'", 14, 1, 15))))),
+                                Some(Expression::Literal(Literal::String(Token::new(Cow::from(&b"foo"[..]), Span::new_at(b"'foo'", 14, 1, 15))))),
                                 Expression::Name(Name::Unqualified(Span::new_at(b"true", 23, 1, 24)))
                             )
                         ])


### PR DESCRIPTION
A string is no longer copied by default. A single quoted string is copied if and only if it contains an escaped character, because the resulting string must not contain the escaping character, and this is not possible to concatenate slices, so the new string is copied inside a `Vec<u8>`. However, if no character is escaped, or if it is a nowdoc string, there is no longer any copy.

Behind the scene, we use a clone-on-write smart pointer: `std::borrow::Cow`.

A benchmark needs to validate this work though, but I am confident it will improve the global performance, let's see.

Interesting commits are:

  * https://github.com/tagua-vm/parser/commit/a4e2688f1df002d647e36f25d06a8803c63589fd the real changeset,
  * https://github.com/tagua-vm/parser/commit/884b6da4a2d359eda7d0e897b0ec4ab6c1630e1b new test cases ensuring whether the string have been copied or not.

cc @jubianchi @Geal