### PR TITLE
AST: Use `SmallVec` for `Name`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,11 @@ simd = ["bytecount/simd-accel"]
 avx  = ["bytecount/avx-accel"]
 
 [dependencies]
-lazy_static = "~0.2"
-regex       = "~0.2"
 bytecount   = "~0.1"
+lazy_static = "~0.2"
 memchr      = "~1.0"
+regex       = "~0.2"
+smallvec    = "~0.4"
 
 [dependencies.nom]
 version  = "~3.0"

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -326,6 +326,8 @@ pub enum Name<'a> {
     /// # Examples
     ///
     /// ```
+    /// # extern crate smallvec;
+    /// # #[macro_use]
     /// # extern crate tagua_parser;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
@@ -340,7 +342,7 @@ pub enum Name<'a> {
     ///     qualified_name(Span::new(b"Foo\\Bar")),
     ///     Result::Done(
     ///         Span::new_at(b"", 7, 1, 8),
-    ///         Name::Qualified(vec![
+    ///         Name::Qualified(smallvec![
     ///             Span::new(b"Foo"),
     ///             Span::new_at(b"Bar", 4, 1, 5)
     ///         ])
@@ -356,6 +358,8 @@ pub enum Name<'a> {
     /// # Examples
     ///
     /// ```
+    /// # extern crate smallvec;
+    /// # #[macro_use]
     /// # extern crate tagua_parser;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
@@ -370,7 +374,7 @@ pub enum Name<'a> {
     ///     qualified_name(Span::new(b"namespace\\Foo\\Bar")),
     ///     Result::Done(
     ///         Span::new_at(b"", 17, 1, 18),
-    ///         Name::RelativeQualified(vec![
+    ///         Name::RelativeQualified(smallvec![
     ///             Span::new_at(b"Foo", 10, 1, 11),
     ///             Span::new_at(b"Bar", 14, 1, 15)
     ///         ])
@@ -387,6 +391,8 @@ pub enum Name<'a> {
     /// # Examples
     ///
     /// ```
+    /// # extern crate smallvec;
+    /// # #[macro_use]
     /// # extern crate tagua_parser;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::Name;
@@ -401,7 +407,7 @@ pub enum Name<'a> {
     ///     qualified_name(Span::new(b"\\Foo\\Bar")),
     ///     Result::Done(
     ///         Span::new_at(b"", 8, 1, 9),
-    ///         Name::FullyQualified(vec![
+    ///         Name::FullyQualified(smallvec![
     ///             Span::new_at(b"Foo", 1, 1, 2),
     ///             Span::new_at(b"Bar", 5, 1, 6)
     ///         ])
@@ -790,6 +796,8 @@ pub enum Expression<'a> {
     /// # Examples
     ///
     /// ```
+    /// # extern crate smallvec;
+    /// # #[macro_use]
     /// # extern crate tagua_parser;
     /// use tagua_parser::Result;
     /// use tagua_parser::ast::{Expression, Name};
@@ -805,7 +813,7 @@ pub enum Expression<'a> {
     ///     Result::Done(
     ///         Span::new_at(b"", 7, 1, 8),
     ///         Expression::Name(
-    ///             Name::Qualified(vec![
+    ///             Name::Qualified(smallvec![
     ///                 Span::new(b"Foo"),
     ///                 Span::new_at(b"Bar", 4, 1, 5)
     ///             ])

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -31,6 +31,7 @@
 
 //! Structures that will constitute the Abstract Syntax Tree.
 
+use smallvec::SmallVec;
 use std::borrow::Cow;
 use super::tokens::{
     Span,
@@ -347,7 +348,7 @@ pub enum Name<'a> {
     /// );
     /// # }
     /// ```
-    Qualified(Vec<Span<'a>>),
+    Qualified(SmallVec<[Span<'a>; 5]>),
 
     /// A relative qualified name, i.e. a name in a relative namespace
     /// restricted to the current namespace, like `namespace\Foo\Bar`.
@@ -378,7 +379,7 @@ pub enum Name<'a> {
     /// # }
     /// ```
     /// Note that the `namespace` part is not present.
-    RelativeQualified(Vec<Span<'a>>),
+    RelativeQualified(SmallVec<[Span<'a>; 5]>),
 
     /// A fully qualified name, i.e. a name in an absolute namespace, like
     /// `\Foo\Bar`.
@@ -409,7 +410,7 @@ pub enum Name<'a> {
     /// # }
     /// ```
     /// Note that the leading `\` part is not present.
-    FullyQualified(Vec<Span<'a>>)
+    FullyQualified(SmallVec<[Span<'a>; 5]>)
 }
 
 /// An expression.

--- a/source/internal.rs
+++ b/source/internal.rs
@@ -31,6 +31,8 @@
 
 //! Internal utilities for the parser.
 
+use smallvec::VecLike;
+
 /// Contain the error that a parser can return.
 pub use nom::Err as Error;
 
@@ -75,7 +77,7 @@ pub type Input<'a> = &'a [InputElement];
 /// assert_eq!(test(&b"abcabc"[..]), Result::Done(&b""[..], vec![&b"abc"[..], &b"abc"[..]]));
 /// # }
 /// ```
-pub fn fold_into_vector<T>(mut accumulator: Vec<T>, item: T) -> Vec<T> {
+pub fn fold_into_vector<I, V: VecLike<I>>(mut accumulator: V, item: I) -> V {
     accumulator.push(item);
 
     accumulator

--- a/source/lib.rs
+++ b/source/lib.rs
@@ -59,13 +59,14 @@
 // Increase the macro recursion limit.
 #![recursion_limit="128"]
 
+extern crate bytecount;
 #[macro_use]
 extern crate lazy_static;
+extern crate memchr;
 #[macro_use]
 extern crate nom;
 extern crate regex;
-extern crate memchr;
-extern crate bytecount;
+extern crate smallvec;
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;

--- a/source/macros.rs
+++ b/source/macros.rs
@@ -349,6 +349,16 @@ macro_rules! regex (
     )
 );
 
+#[macro_export]
+macro_rules! smallvec [
+    ($($e:expr),*) => ({
+        let mut output = ::smallvec::SmallVec::new();
+        $(output.push($e);)*
+
+        output
+    })
+];
+
 
 #[cfg(test)]
 mod tests {

--- a/source/rules/comments.rs
+++ b/source/rules/comments.rs
@@ -47,7 +47,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::rules::comments::comment;
         use tagua_parser::tokens::Span;

--- a/source/rules/expressions/mod.rs
+++ b/source/rules/expressions/mod.rs
@@ -48,7 +48,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -87,7 +87,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal};
@@ -157,7 +156,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::{Expression, Literal, Variable};
@@ -898,6 +896,9 @@ named_attr!(
         # Examples
 
         ```
+        # extern crate smallvec;
+        # #[macro_use]
+        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::{
             AnonymousFunction,
@@ -931,12 +932,12 @@ named_attr!(
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b\"I\", 16, 1, 17), Span::new_at(b\"J\", 18, 1, 19)]))),
+                                ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b\"I\", 16, 1, 17), Span::new_at(b\"J\", 18, 1, 19)]))),
                                 name : Variable(Span::new_at(b\"y\", 21, 1, 22)),
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b\"int\", 24, 1, 25)]))),
+                                ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b\"int\", 24, 1, 25)]))),
                                 name : Variable(Span::new_at(b\"z\", 30, 1, 31)),
                                 value: None
                             }
@@ -1511,7 +1512,7 @@ mod tests {
         let output = Result::Done(
             Span::new_at(b"", 7, 1, 8),
             Expression::Name(
-                Name::Qualified(vec![
+                Name::Qualified(smallvec![
                     Span::new(b"Foo"),
                     Span::new_at(b"Bar", 4, 1, 5)
                 ])
@@ -2411,7 +2412,7 @@ mod tests {
                     declaration_scope: Scope::Dynamic,
                     inputs           : Arity::Finite(vec![
                         Parameter {
-                            ty   : Ty::Copy(Some(Name::Qualified(vec![Span::new_at(b"A", 10, 1, 11), Span::new_at(b"B", 12, 1, 13), Span::new_at(b"C", 14, 1, 15)]))),
+                            ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"A", 10, 1, 11), Span::new_at(b"B", 12, 1, 13), Span::new_at(b"C", 14, 1, 15)]))),
                             name : Variable(Span::new_at(b"x", 17, 1, 18)),
                             value: None
                         }
@@ -2438,7 +2439,7 @@ mod tests {
                     declaration_scope: Scope::Dynamic,
                     inputs           : Arity::Finite(vec![
                         Parameter {
-                            ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"int", 10, 1, 11)]))),
+                            ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 10, 1, 11)]))),
                             name : Variable(Span::new_at(b"x", 16, 1, 17)),
                             value: None
                         }
@@ -2470,17 +2471,17 @@ mod tests {
                             value: None
                         },
                         Parameter {
-                            ty   : Ty::Copy(Some(Name::Qualified(vec![Span::new_at(b"I", 14, 1, 15), Span::new_at(b"J", 16, 1, 17)]))),
+                            ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"I", 14, 1, 15), Span::new_at(b"J", 16, 1, 17)]))),
                             name : Variable(Span::new_at(b"b", 19, 1, 20)),
                             value: None
                         },
                         Parameter {
-                            ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"int", 22, 1, 23)]))),
+                            ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 22, 1, 23)]))),
                             name : Variable(Span::new_at(b"c", 28, 1, 29)),
                             value: None
                         },
                         Parameter {
-                            ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b"K", 32, 1, 33)]))),
+                            ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b"K", 32, 1, 33)]))),
                             name : Variable(Span::new_at(b"d", 35, 1, 36)),
                             value: None
                         }
@@ -2506,7 +2507,7 @@ mod tests {
                 AnonymousFunction {
                     declaration_scope: Scope::Dynamic,
                     inputs           : Arity::Constant,
-                    output           : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b"O", 14, 1, 15)]))),
+                    output           : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b"O", 14, 1, 15)]))),
                     enclosing_scope  : None,
                     body             : vec![Statement::Return]
                 }
@@ -2527,7 +2528,7 @@ mod tests {
                 AnonymousFunction {
                     declaration_scope: Scope::Dynamic,
                     inputs           : Arity::Constant,
-                    output           : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"int", 14, 1, 15)]))),
+                    output           : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 14, 1, 15)]))),
                     enclosing_scope  : None,
                     body             : vec![Statement::Return]
                 }

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -68,7 +68,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::literal;
@@ -105,7 +104,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::null;
@@ -144,7 +142,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::boolean;
@@ -185,7 +182,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::integer;
@@ -221,7 +217,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::binary;
@@ -269,7 +264,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::octal;
@@ -323,7 +317,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::decimal;
@@ -381,7 +374,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::decimal;
@@ -429,7 +421,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;
         use tagua_parser::rules::literals::exponential;
@@ -492,7 +483,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use std::borrow::Cow;
         use tagua_parser::Result;
         use tagua_parser::ast::Literal;

--- a/source/rules/mod.rs
+++ b/source/rules/mod.rs
@@ -51,7 +51,6 @@ use super::tokens::Span;
 /// # Examples
 ///
 /// ```
-/// # extern crate tagua_parser;
 /// use std::borrow::Cow;
 /// use tagua_parser::ast::{
 ///     Expression,

--- a/source/rules/skip.rs
+++ b/source/rules/skip.rs
@@ -49,7 +49,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::rules::skip::skip;
         use tagua_parser::tokens::Span;

--- a/source/rules/statements/function.rs
+++ b/source/rules/statements/function.rs
@@ -90,6 +90,9 @@ named_attr!(
         The arity of this function is finite.
 
         ```
+        # extern crate smallvec;
+        # #[macro_use]
+        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::{
             Arity,
@@ -121,12 +124,12 @@ named_attr!(
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b\"I\", 17, 1, 18), Span::new_at(b\"J\", 19, 1, 20)]))),
+                                ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b\"I\", 17, 1, 18), Span::new_at(b\"J\", 19, 1, 20)]))),
                                 name : Variable(Span::new_at(b\"y\", 22, 1, 23)),
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b\"int\", 25, 1, 26)]))),
+                                ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b\"int\", 25, 1, 26)]))),
                                 name : Variable(Span::new_at(b\"z\", 31, 1, 32)),
                                 value: None
                             }
@@ -145,6 +148,9 @@ named_attr!(
         arguments.
 
         ```
+        # extern crate smallvec;
+        # #[macro_use]
+        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::{
             Arity,
@@ -176,7 +182,7 @@ named_attr!(
                                 value: None
                             },
                             Parameter {
-                                ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b\"int\", 15, 1, 16)]))),
+                                ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b\"int\", 15, 1, 16)]))),
                                 name : Variable(Span::new_at(b\"y\", 23, 1, 24)),
                                 value: None
                             }
@@ -225,6 +231,9 @@ named_attr!(
         # Examples
 
         ```
+        # extern crate smallvec;
+        # #[macro_use]
+        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::{
             Arity,
@@ -251,12 +260,12 @@ named_attr!(
                         value: None
                     },
                     Parameter {
-                        ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b\"I\", 6, 1, 7), Span::new_at(b\"J\", 8, 1, 9)]))),
+                        ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b\"I\", 6, 1, 7), Span::new_at(b\"J\", 8, 1, 9)]))),
                         name : Variable(Span::new_at(b\"y\", 11, 1, 12)),
                         value: None
                     },
                     Parameter {
-                        ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b\"int\", 14, 1, 15)]))),
+                        ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b\"int\", 14, 1, 15)]))),
                         name : Variable(Span::new_at(b\"z\", 20, 1, 21)),
                         value: None
                     }
@@ -402,6 +411,9 @@ named!(
         # Examples
 
         ```
+        # extern crate smallvec;
+        # #[macro_use]
+        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Name;
         use tagua_parser::rules::statements::function::native_type;
@@ -415,7 +427,7 @@ named!(
             native_type(Span::new(b\"int\")),
             Result::Done(
                 Span::new_at(b\"\", 3, 1, 4),
-                Name::FullyQualified(vec![Span::new(b\"int\")])
+                Name::FullyQualified(smallvec![Span::new(b\"int\")])
             )
         );
         # }
@@ -560,17 +572,17 @@ mod tests {
                             value: None
                         },
                         Parameter {
-                            ty   : Ty::Copy(Some(Name::Qualified(vec![Span::new_at(b"I", 15, 1, 16), Span::new_at(b"J", 17, 1, 18)]))),
+                            ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"I", 15, 1, 16), Span::new_at(b"J", 17, 1, 18)]))),
                             name : Variable(Span::new_at(b"b", 20, 1, 21)),
                             value: None
                         },
                         Parameter {
-                            ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"int", 23, 1, 24)]))),
+                            ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 23, 1, 24)]))),
                             name : Variable(Span::new_at(b"c", 29, 1, 30)),
                             value: None
                         },
                         Parameter {
-                            ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b"K", 33, 1, 34)]))),
+                            ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b"K", 33, 1, 34)]))),
                             name : Variable(Span::new_at(b"d", 36, 1, 37)),
                             value: None
                         }
@@ -600,12 +612,12 @@ mod tests {
                             value: None
                         },
                         Parameter {
-                            ty   : Ty::Copy(Some(Name::Qualified(vec![Span::new_at(b"I", 15, 1, 16), Span::new_at(b"J", 17, 1, 18)]))),
+                            ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"I", 15, 1, 16), Span::new_at(b"J", 17, 1, 18)]))),
                             name : Variable(Span::new_at(b"b", 20, 1, 21)),
                             value: None
                         },
                         Parameter {
-                            ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"int", 23, 1, 24)]))),
+                            ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 23, 1, 24)]))),
                             name : Variable(Span::new_at(b"c", 32, 1, 33)),
                             value: None
                         }
@@ -629,7 +641,7 @@ mod tests {
                 Function {
                     name  : Span::new_at(b"f", 9, 1, 10),
                     inputs: Arity::Constant,
-                    output: Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b"O", 15, 1, 16)]))),
+                    output: Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b"O", 15, 1, 16)]))),
                     body  : vec![Statement::Return]
                 }
             )
@@ -648,7 +660,7 @@ mod tests {
                 Function {
                     name  : Span::new_at(b"f", 10, 1, 11),
                     inputs: Arity::Constant,
-                    output: Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"int", 15, 1, 16)]))),
+                    output: Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 15, 1, 16)]))),
                     body  : vec![Statement::Return]
                 }
             )
@@ -707,7 +719,7 @@ mod tests {
             Span::new_at(b"", 10, 1, 11),
             Arity::Finite(vec![
                 Parameter {
-                    ty   : Ty::Copy(Some(Name::Qualified(vec![Span::new_at(b"A", 1, 1, 2), Span::new_at(b"B", 3, 1, 4), Span::new_at(b"C", 5, 1, 6)]))),
+                    ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"A", 1, 1, 2), Span::new_at(b"B", 3, 1, 4), Span::new_at(b"C", 5, 1, 6)]))),
                     name : Variable(Span::new_at(b"x", 8, 1, 9)),
                     value: None
                 }
@@ -724,7 +736,7 @@ mod tests {
             Span::new_at(b"", 9, 1, 10),
             Arity::Finite(vec![
                 Parameter {
-                    ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"int", 1, 1, 2)]))),
+                    ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 1, 1, 2)]))),
                     name : Variable(Span::new_at(b"x", 7, 1, 8)),
                     value: None
                 }
@@ -809,7 +821,7 @@ mod tests {
             Span::new_at(b"", 16, 1, 17),
             Arity::Finite(vec![
                 Parameter {
-                    ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b"float", 1, 1, 2)]))),
+                    ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b"float", 1, 1, 2)]))),
                     name : Variable(Span::new_at(b"x", 8, 1, 9)),
                     value: Some(Expression::Literal(Literal::Real(Token::new(4.2f64, Span::new_at(b"4.2", 12, 1, 13)))))
                 }
@@ -826,7 +838,7 @@ mod tests {
             Span::new_at(b"", 29, 1, 30),
             Arity::Finite(vec![
                 Parameter {
-                    ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"array", 1, 1, 2)]))),
+                    ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"array", 1, 1, 2)]))),
                     name : Variable(Span::new_at(b"x", 9, 1, 10)),
                     value: Some(
                         Expression::Array(vec![
@@ -884,7 +896,7 @@ mod tests {
             Span::new_at(b"", 13, 1, 14),
             Arity::Infinite(vec![
                 Parameter {
-                    ty   : Ty::Copy(Some(Name::Qualified(vec![Span::new_at(b"A", 1, 1, 2), Span::new_at(b"B", 3, 1, 4), Span::new_at(b"C", 5, 1, 6)]))),
+                    ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"A", 1, 1, 2), Span::new_at(b"B", 3, 1, 4), Span::new_at(b"C", 5, 1, 6)]))),
                     name : Variable(Span::new_at(b"x", 11, 1, 12)),
                     value: None
                 }
@@ -901,7 +913,7 @@ mod tests {
             Span::new_at(b"", 12, 1, 13),
             Arity::Infinite(vec![
                 Parameter {
-                    ty   : Ty::Reference(Some(Name::FullyQualified(vec![Span::new_at(b"int", 1, 1, 2)]))),
+                    ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 1, 1, 2)]))),
                     name : Variable(Span::new_at(b"x", 10, 1, 11)),
                     value: None
                 }
@@ -923,12 +935,12 @@ mod tests {
                     value: None
                 },
                 Parameter {
-                    ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b"int", 6, 1, 7)]))),
+                    ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 6, 1, 7)]))),
                     name : Variable(Span::new_at(b"y", 11, 1, 12)),
                     value: None
                 },
                 Parameter {
-                    ty   : Ty::Copy(Some(Name::Qualified(vec![Span::new_at(b"I", 14, 1, 15), Span::new_at(b"J", 16, 1, 17)]))),
+                    ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"I", 14, 1, 15), Span::new_at(b"J", 16, 1, 17)]))),
                     name : Variable(Span::new_at(b"z", 19, 1, 20)),
                     value: None
                 }
@@ -950,12 +962,12 @@ mod tests {
                     value: None
                 },
                 Parameter {
-                    ty   : Ty::Copy(Some(Name::FullyQualified(vec![Span::new_at(b"int", 6, 1, 7)]))),
+                    ty   : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 6, 1, 7)]))),
                     name : Variable(Span::new_at(b"y", 11, 1, 12)),
                     value: None
                 },
                 Parameter {
-                    ty   : Ty::Copy(Some(Name::Qualified(vec![Span::new_at(b"I", 14, 1, 15), Span::new_at(b"J", 16, 1, 17)]))),
+                    ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"I", 14, 1, 15), Span::new_at(b"J", 16, 1, 17)]))),
                     name : Variable(Span::new_at(b"z", 22, 1, 23)),
                     value: None
                 }
@@ -996,7 +1008,7 @@ mod tests {
                 let input  = Span::new($name);
                 let output = Result::Done(
                     Span::new_at(b"", $name.len(), 1, $name.len() as u32 + 1),
-                    Name::FullyQualified(vec![input])
+                    Name::FullyQualified(smallvec![input])
                 );
 
                 assert_eq!(native_type(input), output);

--- a/source/rules/statements/function.rs
+++ b/source/rules/statements/function.rs
@@ -438,7 +438,7 @@ named!(
 
 #[inline]
 fn native_type_mapper(native_type_name: Span) -> Result<Name, ()> {
-    Ok(Name::FullyQualified(vec![native_type_name]))
+    Ok(Name::FullyQualified(smallvec![native_type_name]))
 }
 
 #[inline]

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -35,6 +35,7 @@
 //! the [Grammar chapter, Tokens
 //! section](https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#tokens).
 
+use smallvec::SmallVec;
 use super::super::ast::{
     Name,
     Variable
@@ -157,8 +158,8 @@ named_attr!(
 );
 
 #[inline]
-fn wrap_into_vector_mapper(span: Span) -> Result<Vec<Span>, ()> {
-    Ok(vec![span])
+fn wrap_into_vector_mapper(span: Span) -> Result<SmallVec<[Span; 5]>, ()> {
+    Ok(smallvec![span])
 }
 
 named_attr!(

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -50,7 +50,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Variable;
         use tagua_parser::rules::tokens::variable;
@@ -92,6 +91,8 @@ named_attr!(
         # Examples
 
         ```
+        # extern crate smallvec;
+        # #[macro_use]
         # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::ast::Name;
@@ -103,7 +104,7 @@ named_attr!(
             qualified_name(Span::new(b\"Foo\\\\Bar\\\\Baz\")),
             Result::Done(
                 Span::new_at(b\"\", 11, 1, 12),
-                Name::Qualified(vec![
+                Name::Qualified(smallvec![
                     Span::new_at(b\"Foo\", 0, 1, 1),
                     Span::new_at(b\"Bar\", 4, 1, 5),
                     Span::new_at(b\"Baz\", 8, 1, 9)
@@ -169,7 +170,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::rules::tokens::name;
         use tagua_parser::tokens::Span;
@@ -262,7 +262,7 @@ mod tests {
         let input  = Span::new(b"Foo\\Bar\\Baz");
         let output = Result::Done(
             Span::new_at(b"", 11, 1, 12),
-            Name::Qualified(vec![
+            Name::Qualified(smallvec![
                 Span::new(b"Foo"),
                 Span::new_at(b"Bar", 4, 1, 5),
                 Span::new_at(b"Baz", 8, 1, 9)
@@ -275,8 +275,8 @@ mod tests {
     #[test]
     fn case_qualified_name_vector_capacity() {
         if let Result::Done(_, Name::Qualified(vector)) = qualified_name(Span::new(b"Foo\\Bar\\Baz")) {
-            assert_eq!(vector.capacity(), vector.len());
-            assert_eq!(vector.len(), 3);
+            assert!(vector.capacity() >= vector.len());
+            assert!(vector.len() >= 3);
         } else {
             assert!(false);
         }
@@ -287,7 +287,7 @@ mod tests {
         let input  = Span::new(b"Foo\n/* baz */ \\ Bar /* qux */\\");
         let output = Result::Done(
             Span::new_at(b" /* qux */\\", 19, 2, 16),
-            Name::Qualified(vec![
+            Name::Qualified(smallvec![
                 Span::new(b"Foo"),
                 Span::new_at(b"Bar", 16, 2, 13)
             ])
@@ -319,7 +319,7 @@ mod tests {
         let input  = Span::new(b"namespace\\Foo\\Bar\\Baz");
         let output = Result::Done(
             Span::new_at(b"", 21, 1, 22),
-            Name::RelativeQualified(vec![
+            Name::RelativeQualified(smallvec![
                 Span::new_at(b"Foo", 10, 1, 11),
                 Span::new_at(b"Bar", 14, 1, 15),
                 Span::new_at(b"Baz", 18, 1, 19)
@@ -332,8 +332,8 @@ mod tests {
     #[test]
     fn case_relative_qualified_name_vector_capacity() {
         if let Result::Done(_, Name::RelativeQualified(vector)) = qualified_name(Span::new(b"namespace\\Foo\\Bar\\Baz")) {
-            assert_eq!(vector.capacity(), vector.len());
-            assert_eq!(vector.len(), 3);
+            assert!(vector.capacity() >= vector.len());
+            assert!(vector.len() >= 3);
         } else {
             assert!(false);
         }
@@ -344,7 +344,7 @@ mod tests {
         let input  = Span::new(b"NaMeSpAcE\\Foo\\Bar\\Baz");
         let output = Result::Done(
             Span::new_at(b"", 21, 1, 22),
-            Name::RelativeQualified(vec![
+            Name::RelativeQualified(smallvec![
                 Span::new_at(b"Foo", 10, 1, 11),
                 Span::new_at(b"Bar", 14, 1, 15),
                 Span::new_at(b"Baz", 18, 1, 19)
@@ -359,7 +359,7 @@ mod tests {
         let input  = Span::new(b"namespace/* baz */ \\ Foo\n/* qux */ \\ Bar /* hello */\\");
         let output = Result::Done(
             Span::new_at(b" /* hello */\\", 40, 2, 16),
-            Name::RelativeQualified(vec![
+            Name::RelativeQualified(smallvec![
                 Span::new_at(b"Foo", 21, 1, 22),
                 Span::new_at(b"Bar", 37, 2, 13)
             ])
@@ -377,14 +377,14 @@ mod tests {
             qualified_name(input1),
             Result::Done(
                 Span::new_at(b"\\namespace\\Baz", 13, 1, 14),
-                Name::RelativeQualified(vec![Span::new_at(b"Foo", 10, 1, 11)])
+                Name::RelativeQualified(smallvec![Span::new_at(b"Foo", 10, 1, 11)])
             )
         );
         assert_eq!(
             qualified_name(input2),
             Result::Done(
                 Span::new_at(b"\\NaMeSpAcE\\Baz", 13, 1, 14),
-                Name::RelativeQualified(vec![Span::new_at(b"Foo", 10, 1, 11)])
+                Name::RelativeQualified(smallvec![Span::new_at(b"Foo", 10, 1, 11)])
             )
         );
     }
@@ -403,7 +403,7 @@ mod tests {
         let input  = Span::new(b"\\Foo\\Bar\\Baz");
         let output = Result::Done(
             Span::new_at(b"", 12, 1, 13),
-            Name::FullyQualified(vec![
+            Name::FullyQualified(smallvec![
                 Span::new_at(b"Foo", 1, 1, 2),
                 Span::new_at(b"Bar", 5, 1, 6),
                 Span::new_at(b"Baz", 9, 1, 10)
@@ -416,8 +416,8 @@ mod tests {
     #[test]
     fn case_fully_qualified_name_vector_capacity() {
         if let Result::Done(_, Name::FullyQualified(vector)) = qualified_name(Span::new(b"\\Foo\\Bar\\Baz")) {
-            assert_eq!(vector.capacity(), vector.len());
-            assert_eq!(vector.len(), 3);
+            assert!(vector.capacity() >= vector.len());
+            assert!(vector.len() >= 3);
         } else {
             assert!(false);
         }
@@ -428,7 +428,7 @@ mod tests {
         let input  = Span::new(b"\\Foo");
         let output = Result::Done(
             Span::new_at(b"", 4, 1, 5),
-            Name::FullyQualified(vec![Span::new_at(b"Foo", 1, 1, 2)])
+            Name::FullyQualified(smallvec![Span::new_at(b"Foo", 1, 1, 2)])
         );
 
         assert_eq!(qualified_name(input), output);
@@ -455,7 +455,7 @@ mod tests {
         let input  = Span::new(b"Foo\\Bar\\");
         let output = Result::Done(
             Span::new_at(b"\\", 7, 1, 8),
-            Name::Qualified(vec![
+            Name::Qualified(smallvec![
                 Span::new(b"Foo"),
                 Span::new_at(b"Bar", 4, 1, 5)
             ])

--- a/source/rules/tokens.rs
+++ b/source/rules/tokens.rs
@@ -275,8 +275,8 @@ mod tests {
     #[test]
     fn case_qualified_name_vector_capacity() {
         if let Result::Done(_, Name::Qualified(vector)) = qualified_name(Span::new(b"Foo\\Bar\\Baz")) {
-            assert!(vector.capacity() >= vector.len());
-            assert!(vector.len() >= 3);
+            assert_eq!(vector.capacity(), 5);
+            assert_eq!(vector.len(), 3);
         } else {
             assert!(false);
         }
@@ -416,8 +416,8 @@ mod tests {
     #[test]
     fn case_fully_qualified_name_vector_capacity() {
         if let Result::Done(_, Name::FullyQualified(vector)) = qualified_name(Span::new(b"\\Foo\\Bar\\Baz")) {
-            assert!(vector.capacity() >= vector.len());
-            assert!(vector.len() >= 3);
+            assert_eq!(vector.capacity(), 5);
+            assert_eq!(vector.len(), 3);
         } else {
             assert!(false);
         }

--- a/source/rules/whitespaces.rs
+++ b/source/rules/whitespaces.rs
@@ -44,7 +44,6 @@ named_attr!(
         # Examples
 
         ```
-        # extern crate tagua_parser;
         use tagua_parser::Result;
         use tagua_parser::rules::whitespaces::whitespace;
         use tagua_parser::tokens::Span;


### PR DESCRIPTION
The `Name` enum uses small vectors instead of vectors to represent part of the names (if `Qualified`, `RelativeQualified`, and `FullyQualified`). Small vectors are located on the stack if the number of items is lower than $N$, after that they are located on the heap.

The number $N = 5$ is strictly arbitrary so far.

The most important commit is https://github.com/tagua-vm/parser/commit/05355297a971489a960a0bb1e0dfd1dee60310c7.