### PR TITLE
feat(parser) Add the `relative_scope` parser

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -1359,6 +1359,24 @@ pub enum Scope {
     Static
 }
 
+/// A relative scope designates the class with relation to the current
+/// class scope.
+#[derive(Debug, PartialEq)]
+pub enum RelativeScope {
+    /// From within a class, `self` refers to the same class.
+    ToSelf,
+
+    /// From within a class, `parent` refers to the class the current
+    /// class extends from.
+    ToParent,
+
+    /// From within a method, `static` refers to the class corresponds
+    /// to the class inheritance context in whcih the method is
+    /// called. This allows late static binding, when class resolution
+    /// depends on the dynamic call context.
+    ToStatic
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/source/tokens.rs
+++ b/source/tokens.rs
@@ -500,6 +500,10 @@ token!(
     "The `OR` token.\n\nRepresent the inclusive disjunction operator, used in a logical expression, e.g. `$x or $y`."
 );
 token!(
+    pub PARENT: b"parent";
+    "The `PARENT` token.\n\nRepresent the parent scope resolution qualifier, e.g. `parent::$x`."
+);
+token!(
     pub POW: b"**";
     "The `POW` token.\n\nRepresent the power operator, e.g. `$x ** $y`."
 );
@@ -552,12 +556,16 @@ token!(
     "The `RIGHT_SQUARE_BRACKET` token.\n\nUsed to close an array construction or an array access for instance, e.g. `[2, 4, 6, 9][0]`."
 );
 token!(
+    pub SELF: b"self";
+    "The `SELF` token.\n\nRepresent the self scope resolution qualifier, e.g. `self::$x`."
+);
+token!(
     pub SEMICOLON: b";";
     "The `SEMICOLON` token.\n\nRepresent the end of an instruction, e.g. `$x = …;`."
 );
 token!(
     pub STATIC: b"static";
-    "The `STATIC` token.\n\nRepresent the stack declaration operator, e.g. `static $x`."
+    "The `STATIC` token.\n\nRepresent the stack declaration operator or the static scope resolution qualifier, e.g. `static $x` or `static::$x`."
 );
 token!(
     pub STATIC_CALL: b"::";


### PR DESCRIPTION
Address https://github.com/tagua-vm/parser/issues/68.

This patch introduces new tokens: `SELF`, `PARENT` (`STATIC` is already present, its definition has been modified though), and the new `relative_scope` parser.