### PR TITLE
feat(parser) Implement the `scope-resolution-qualifier` rule

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -941,6 +941,25 @@ pub enum Expression<'a> {
     Variable(Variable<'a>)
 }
 
+/// A dereferencable expression.
+///
+/// A dereferencable expression can be used as the left hand side of
+/// dereferencing operators, such as `[]`, `->`, and `::`.
+#[derive(Debug, PartialEq)]
+pub enum DereferencableExpression<'a> {
+    /// A variable.
+    Variable(Variable<'a>),
+
+    /// An expression evaluating to either an array or a string.
+    Expression(Expression<'a>),
+
+    /// An array.
+    Array(Expression<'a>),
+
+    /// A string.
+    String(Literal<'a>)
+}
+
 /// A type declaration.
 ///
 /// A type holds two informations: Name, and copy or reference. A type

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -1396,6 +1396,19 @@ pub enum RelativeScope {
     ToStatic
 }
 
+/// A scope resolution qualifier.
+#[derive(Debug, PartialEq)]
+pub enum ScopeResolver<'a> {
+    /// A relative scope.
+    ByRelative(RelativeScope),
+
+    /// A scope defined by a name.
+    ByName(Name<'a>),
+
+    /// A scope defined by a dereferencable expression.
+    ByExpression(DereferencableExpression<'a>)
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/source/ast.rs
+++ b/source/ast.rs
@@ -437,7 +437,7 @@ pub enum Expression<'a> {
     ///     Expression,
     ///     Name,
     ///     Parameter,
-    ///     Scope,
+    ///     DeclarationScope,
     ///     Statement,
     ///     Ty,
     ///     Variable
@@ -455,7 +455,7 @@ pub enum Expression<'a> {
     ///         Span::new_at(b"", 46, 1, 47),
     ///         Expression::AnonymousFunction(
     ///             AnonymousFunction {
-    ///                 declaration_scope: Scope::Dynamic,
+    ///                 declaration_scope: DeclarationScope::Dynamic,
     ///                 inputs           : Arity::Finite(vec![
     ///                     Parameter {
     ///                         ty   : Ty::Copy(Some(Name::Unqualified(Span::new_at(b"I", 10, 1, 11)))),
@@ -1278,7 +1278,7 @@ pub struct Function<'a> {
 ///     Expression,
 ///     Name,
 ///     Parameter,
-///     Scope,
+///     DeclarationScope,
 ///     Statement,
 ///     Ty,
 ///     Variable
@@ -1296,7 +1296,7 @@ pub struct Function<'a> {
 ///         Span::new_at(b"", 55, 1, 56),
 ///         Expression::AnonymousFunction(
 ///             AnonymousFunction {
-///                 declaration_scope: Scope::Static,
+///                 declaration_scope: DeclarationScope::Static,
 ///                 inputs           : Arity::Infinite(vec![
 ///                     Parameter {
 ///                         ty   : Ty::Copy(Some(Name::Unqualified(Span::new_at(b"I", 18, 1, 19)))),
@@ -1323,7 +1323,7 @@ pub struct Function<'a> {
 #[derive(Debug, PartialEq)]
 pub struct AnonymousFunction<'a> {
     /// Declaration scope of the anonymous function.
-    pub declaration_scope: Scope,
+    pub declaration_scope: DeclarationScope,
 
     /// Inputs, aka parameters, of the anonymous function.
     pub inputs: Arity<'a>,
@@ -1349,9 +1349,9 @@ pub enum Statement<'a> {
     Return
 }
 
-/// A scope.
+/// A declaration scope.
 #[derive(Debug, PartialEq)]
-pub enum Scope {
+pub enum DeclarationScope {
     /// A dynamic scope (default one).
     Dynamic,
 

--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -50,11 +50,11 @@ use super::super::tokens::{
 use super::super::super::ast::{
     AnonymousFunction,
     Arity,
+    DeclarationScope,
     Expression,
     Literal,
     Name,
     RelativeScope,
-    Scope,
     Statement,
     Ty,
     Variable
@@ -948,7 +948,7 @@ named_attr!(
             Expression,
             Name,
             Parameter,
-            Scope,
+            DeclarationScope,
             Statement,
             Ty,
             Variable
@@ -966,7 +966,7 @@ named_attr!(
                 Span::new_at(b\"\", 61, 1, 62),
                 Expression::AnonymousFunction(
                     AnonymousFunction {
-                        declaration_scope: Scope::Dynamic,
+                        declaration_scope: DeclarationScope::Dynamic,
                         inputs           : Arity::Finite(vec![
                             Parameter {
                                 ty   : Ty::Copy(None),
@@ -1022,11 +1022,11 @@ named_attr!(
             into_anonymous_function(
                 match static_scope {
                     Some(_) => {
-                        Scope::Static
+                        DeclarationScope::Static
                     },
 
                     None => {
-                        Scope::Dynamic
+                        DeclarationScope::Dynamic
                     }
                 },
                 output_is_a_reference.is_some(),
@@ -1107,7 +1107,7 @@ fn into_anonymous_function_use_list_item(reference: bool, name: Variable) -> Exp
 
 #[inline]
 fn into_anonymous_function<'a>(
-    declaration_scope    : Scope,
+    declaration_scope    : DeclarationScope,
     output_is_a_reference: bool,
     inputs               : Arity<'a>,
     output_type          : Option<Name<'a>>,
@@ -1156,12 +1156,12 @@ mod tests {
     use super::super::super::super::ast::{
         AnonymousFunction,
         Arity,
+        DeclarationScope,
         Expression,
         Literal,
         Name,
         Parameter,
         RelativeScope,
-        Scope,
         Statement,
         Ty,
         Variable
@@ -2370,7 +2370,7 @@ mod tests {
             Span::new_at(b"", 46, 1, 47),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Finite(vec![
                         Parameter {
                             ty   : Ty::Copy(Some(Name::Unqualified(Span::new_at(b"I", 10, 1, 11)))),
@@ -2402,7 +2402,7 @@ mod tests {
             Span::new_at(b"", 14, 1, 15),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Constant,
                     output           : Ty::Copy(None),
                     enclosing_scope  : None,
@@ -2423,7 +2423,7 @@ mod tests {
             Span::new_at(b"", 16, 1, 17),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Finite(vec![
                         Parameter {
                             ty   : Ty::Copy(None),
@@ -2450,7 +2450,7 @@ mod tests {
             Span::new_at(b"", 17, 1, 18),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Finite(vec![
                         Parameter {
                             ty   : Ty::Reference(None),
@@ -2477,7 +2477,7 @@ mod tests {
             Span::new_at(b"", 22, 1, 23),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Finite(vec![
                         Parameter {
                             ty   : Ty::Copy(Some(Name::Qualified(smallvec![Span::new_at(b"A", 10, 1, 11), Span::new_at(b"B", 12, 1, 13), Span::new_at(b"C", 14, 1, 15)]))),
@@ -2504,7 +2504,7 @@ mod tests {
             Span::new_at(b"", 21, 1, 22),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Finite(vec![
                         Parameter {
                             ty   : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 10, 1, 11)]))),
@@ -2531,7 +2531,7 @@ mod tests {
             Span::new_at(b"", 40, 1, 41),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Finite(vec![
                         Parameter {
                             ty   : Ty::Copy(None),
@@ -2573,7 +2573,7 @@ mod tests {
             Span::new_at(b"", 18, 1, 19),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Constant,
                     output           : Ty::Copy(Some(Name::FullyQualified(smallvec![Span::new_at(b"O", 14, 1, 15)]))),
                     enclosing_scope  : None,
@@ -2594,7 +2594,7 @@ mod tests {
             Span::new_at(b"", 20, 1, 21),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Constant,
                     output           : Ty::Reference(Some(Name::FullyQualified(smallvec![Span::new_at(b"int", 14, 1, 15)]))),
                     enclosing_scope  : None,
@@ -2615,7 +2615,7 @@ mod tests {
             Span::new_at(b"", 21, 1, 22),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Constant,
                     output           : Ty::Copy(None),
                     enclosing_scope  : Some(vec![]),
@@ -2636,7 +2636,7 @@ mod tests {
             Span::new_at(b"", 23, 1, 24),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Constant,
                     output           : Ty::Copy(None),
                     enclosing_scope  : Some(vec![
@@ -2659,7 +2659,7 @@ mod tests {
             Span::new_at(b"", 24, 1, 25),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Constant,
                     output           : Ty::Copy(None),
                     enclosing_scope  : Some(vec![
@@ -2686,7 +2686,7 @@ mod tests {
             Span::new_at(b"", 32, 1, 33),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Dynamic,
+                    declaration_scope: DeclarationScope::Dynamic,
                     inputs           : Arity::Constant,
                     output           : Ty::Copy(None),
                     enclosing_scope  : Some(vec![
@@ -2715,7 +2715,7 @@ mod tests {
             Span::new_at(b"", 21, 1, 22),
             Expression::AnonymousFunction(
                 AnonymousFunction {
-                    declaration_scope: Scope::Static,
+                    declaration_scope: DeclarationScope::Static,
                     inputs           : Arity::Constant,
                     output           : Ty::Copy(None),
                     enclosing_scope  : None,


### PR DESCRIPTION
Address https://github.com/tagua-vm/parser/issues/68.

* [x] Implement dereferencable expression,
* [x] Implement scope resolver,
* [x] Implement scope resolution qualifier.

Important note, see https://github.com/php/php-langspec/issues/200.