### PR TITLE
feat(parser) Deref expr. accept single q. string

### DIFF
--- a/source/rules/expressions/primaries.rs
+++ b/source/rules/expressions/primaries.rs
@@ -39,7 +39,7 @@ use std::result::Result as StdResult;
 use super::expression;
 use super::super::literals::{
     literal,
-    string
+    string_single_quoted
 };
 use super::super::statements::compound_statement;
 use super::super::statements::function::{
@@ -227,9 +227,9 @@ named_attr!(
                 first!(expression),
                 first!(tag!(tokens::RIGHT_PARENTHESIS))
             )
-        )        => { dereferencable_sub_expression_mapper }
-      | array    => { dereferencable_array_mapper }
-      | string   => { dereferencable_string_mapper }
+        )                    => { dereferencable_sub_expression_mapper }
+      | array                => { dereferencable_array_mapper }
+      | string_single_quoted => { dereferencable_string_mapper }
     )
 );
 

--- a/source/rules/literals.rs
+++ b/source/rules/literals.rs
@@ -510,7 +510,10 @@ named_attr!(
     )
 );
 
-fn string_single_quoted(span: Span) -> Result<Span, Literal> {
+/// Recognize a single quoted string.
+///
+/// See the `string` parser for more details.
+pub fn string_single_quoted(span: Span) -> Result<Span, Literal> {
     let input        = span.as_slice();
     let input_length = span.input_len();
 


### PR DESCRIPTION
Dereferencable expressions only accept single quoted strings for now.

See https://github.com/tagua-vm/parser/issues/118 and
https://github.com/php/php-langspec/issues/200 for more details.