### PR TITLE
Introduce ternary operator

### DIFF
--- a/source/ast.rs
+++ b/source/ast.rs
@@ -1686,6 +1686,21 @@ pub enum NAryOperation<'a> {
 
         /// The right operand (`y`).
         right_operand: Box<NAryOperation<'a>>
+    },
+
+    /// An operation with one operator and three operands: `x op y op z`.
+    Ternary {
+        /// The operator.
+        operator: TernaryOperator,
+
+        /// The left operand (`x`).
+        left_operand: Box<NAryOperation<'a>>,
+
+        /// The middle operand (`y`).
+        middle_operand: Box<Expression<'a>>,
+
+        /// The right operand (`y`).
+        right_operand: Box<NAryOperation<'a>>
     }
 }
 
@@ -1741,6 +1756,9 @@ pub enum BinaryOperator {
     /// `$x <=> $y`.
     Comparison,
 
+    /// `$x ?: $z`, i.e. `$x ? $y : $z` with `$y` being optional.
+    Conditional,
+
     /// `$x / $y`.
     Division,
 
@@ -1791,6 +1809,13 @@ pub enum BinaryOperator {
 
     /// `$x + $y`.
     Plus
+}
+
+/// A ternary operator.
+#[derive(Debug, PartialEq)]
+pub enum TernaryOperator {
+    /// `$x ? $y : $z`.
+    Conditional
 }
 
 /// A cast type.


### PR DESCRIPTION
Address https://github.com/tagua-vm/parser/issues/14.

Only `conditional` is introduced now (I don't think there is more though).

New AST nodes: `NAryOperation::Ternary` and `TernaryOperator`.

In the case of `conditional`, the pattern is `x op_1 y op_2 z` where `y` is optional. In case it is absent, then we automatically fallback to a binary operation instead of a ternary operation. It is why we have `BinaryOperator::Conditional` and `TernaryOperator::Conditional`.